### PR TITLE
replace CMS landing page with custom MelaHomePage

### DIFF
--- a/src/routing/routeConfiguration.js
+++ b/src/routing/routeConfiguration.js
@@ -79,13 +79,13 @@ const routeConfiguration = (layoutConfig, accessControlConfig) => {
     {
       path: '/',
       name: 'LandingPage',
-      component: LandingPage,
-      loadData: pageDataLoadingAPI.LandingPage.loadData,
+      component: MelaHomePage,
     },
     {
-      path: '/mela-home',
-      name: 'MelaHomePage',
-      component: MelaHomePage,
+      path: '/cms-backup',
+      name: 'CMSLandingPage',
+      component: LandingPage,
+      loadData: pageDataLoadingAPI.LandingPage.loadData,
     },
     {
       path: '/p/:pageId',


### PR DESCRIPTION
Set custom MelaHomePage as the root landing page, replacing Sharetribe CMS-based page.

  Changes:
  - Route '/' now renders MelaHomePage (custom product-first homepage)
  - Move old CMS LandingPage to '/cms-backup' for reference
  - Remove '/mela-home' route (no longer needed)

  Impact:
  - Users now see optimized custom homepage at root URL
  - Old CMS page preserved at /cms-backup for comparison
  - All navigation using 'LandingPage' route name works unchanged

  🤖 Generated with Claude Code