### PR TITLE
mobile modals render at page bottom instead of overlaying viewport

### DIFF
--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -73,9 +73,14 @@
 
 .isOpenInPortal {
   composes: isOpen;
-  display: block;
+  display: flex;
+  flex-direction: column;
   height: calc(var(--vh, 1vh) * 100);
-  position: absolute;
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
 
   @media (--viewportMedium) {
     display: flex;

--- a/src/containers/MelaHomePage/MelaHomePage.js
+++ b/src/containers/MelaHomePage/MelaHomePage.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { string } from 'prop-types';
 
-import { Page, LayoutSingleColumn } from '../../components';
+import { Page } from '../../components';
 import TopbarContainer from '../TopbarContainer/TopbarContainer';
 import FooterContainer from '../FooterContainer/FooterContainer';
 
@@ -59,10 +59,7 @@ const MelaHomePage = props => {
         }
       }}
     >
-      <LayoutSingleColumn
-        topbar={<TopbarContainer />}
-        footer={<FooterContainer />}
-      >
+      <TopbarContainer currentSearchParams={{}} />
       <div className={css.root}>
         {/* Hero Section - Product Showcase + Trust Signals */}
         <section className={css.heroSection}>
@@ -89,7 +86,7 @@ const MelaHomePage = props => {
           <TrustAssurance />
         </section>
       </div>
-      </LayoutSingleColumn>
+      <FooterContainer />
     </Page>
   );
 };


### PR DESCRIPTION
  - Change Modal.isOpenInPortal to position: fixed on mobile
  - Remove LayoutSingleColumn from MelaHomePage, render topbar/footer directly
  - Add currentSearchParams prop to TopbarContainer