### PR TITLE
fix: patch buffer-equal-constant-time for Node 26 compatibility

### DIFF
--- a/patches/buffer-equal-constant-time+1.0.1.patch
+++ b/patches/buffer-equal-constant-time+1.0.1.patch
@@ -1,0 +1,14 @@
+diff --git a/node_modules/buffer-equal-constant-time/index.js b/node_modules/buffer-equal-constant-time/index.js
+index 2a4aded..bebe7ba 100644
+--- a/node_modules/buffer-equal-constant-time/index.js
++++ b/node_modules/buffer-equal-constant-time/index.js
+@@ -1,7 +1,8 @@
+ /*jshint node:true */
+ 'use strict';
+ var Buffer = require('buffer').Buffer; // browserify
+-var SlowBuffer = require('buffer').SlowBuffer;
++// SlowBuffer was removed in Node 26; fall back to a no-op shim so the
++// module-level property reads below don't throw at startup.
++var SlowBuffer = require('buffer').SlowBuffer || { prototype: {} };
+
+ module.exports = bufferEq;


### PR DESCRIPTION
SlowBuffer was removed in Node 26. The package reads SlowBuffer.prototype at module load time, crashing the server before it can serve any requests. Shim SlowBuffer to a no-op object when undefined so the module loads safely.