### PR TITLE
fix: regenerate buffer-equal-constant-time patch with correct format

### DIFF
--- a/patches/buffer-equal-constant-time+1.0.1.patch
+++ b/patches/buffer-equal-constant-time+1.0.1.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/buffer-equal-constant-time/index.js b/node_modules/buffer-equal-constant-time/index.js
-index 2a4aded..bebe7ba 100644
+index 5462c1f..750724e 100644
 --- a/node_modules/buffer-equal-constant-time/index.js
 +++ b/node_modules/buffer-equal-constant-time/index.js
-@@ -1,7 +1,8 @@
+@@ -1,7 +1,9 @@
  /*jshint node:true */
  'use strict';
  var Buffer = require('buffer').Buffer; // browserify
@@ -10,5 +10,6 @@ index 2a4aded..bebe7ba 100644
 +// SlowBuffer was removed in Node 26; fall back to a no-op shim so the
 +// module-level property reads below don't throw at startup.
 +var SlowBuffer = require('buffer').SlowBuffer || { prototype: {} };
-
+ 
  module.exports = bufferEq;
+ 


### PR DESCRIPTION
Previous patch was manually written with wrong hunk line count, causing patch-package to fail silently on Render. Regenerated with npx patch-package to ensure it applies cleanly on install.