### PR TITLE
Add curated brand descriptions to brand cards and storefront

### DIFF
--- a/src/components/BrandCard/BrandCard.js
+++ b/src/components/BrandCard/BrandCard.js
@@ -34,8 +34,10 @@ const BrandCard = props => {
 
   const classes = classNames(rootClassName || css.root, className);
 
-  const { displayName, publicData } = brand.attributes?.profile || {};
-  const { certifications = [] } = publicData || {};
+  const { displayName, bio, publicData } = brand.attributes?.profile || {};
+  const { certifications = [], brandTagline } = publicData || {};
+  const firstSentence = bio ? bio.split('.')[0].trim() : '';
+  const tagline = brandTagline || (firstSentence ? firstSentence.substring(0, 120) : null);
   const profileImage = brand.profileImage;
 
   const logoSrc =
@@ -67,7 +69,10 @@ const BrandCard = props => {
           ) : (
             <div className={css.logoPlaceholder}>{logoInitial}</div>
           )}
-          <h3 className={css.brandName}>{displayName}</h3>
+          <div className={css.brandText}>
+            <h3 className={css.brandName}>{displayName}</h3>
+            {tagline && <p className={css.tagline}>{tagline}</p>}
+          </div>
         </div>
 
         {/* Future: Options menu */}

--- a/src/components/BrandCard/BrandCard.module.css
+++ b/src/components/BrandCard/BrandCard.module.css
@@ -56,17 +56,26 @@
   font-size: 16px;
 }
 
+.brandText {
+  flex: 1;
+  min-width: 0;
+}
+
 .brandName {
   font-size: 16px;
   font-weight: var(--fontWeightSemiBold);
-  margin: 0;
+  margin: 0 0 3px;
   color: var(--colorGrey700);
-
-  /* Truncate if too long */
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  max-width: 200px;
+}
+
+.tagline {
+  font-size: 12px;
+  color: var(--colorGrey500);
+  margin: 0;
+  line-height: 1.45;
 }
 
 .menuButton {

--- a/src/components/BrandCardHome/BrandCardHome.js
+++ b/src/components/BrandCardHome/BrandCardHome.js
@@ -62,11 +62,9 @@ const BrandCardHome = props => {
 
   const logoInitial = displayName?.charAt(0) || 'B';
 
-  // Extract first sentence from bio as tagline (max 80 chars)
+  // First sentence of bio is the tagline; brandTagline from publicData overrides if set
   const firstSentence = bio ? bio.split('.')[0].trim() : '';
-  const tagline = firstSentence
-    ? firstSentence.substring(0, 80) + (firstSentence.length > 80 ? '...' : '')
-    : null;
+  const tagline = publicData?.brandTagline || firstSentence || null;
 
   // Extract brand origin (city, country)
   const brandOrigin =

--- a/src/components/BrandCardHome/BrandCardHome.module.css
+++ b/src/components/BrandCardHome/BrandCardHome.module.css
@@ -100,14 +100,9 @@
 
 .tagline {
   font-size: 13px;
-  line-height: 1.3;
-  color: var(--colorGrey300);
+  line-height: 1.45;
+  color: var(--colorGrey500);
   margin: 0 0 4px 0;
-
-  /* Truncate to 1 line */
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .taglinePlaceholder {
@@ -240,6 +235,7 @@
 
   .tagline {
     font-size: 12px;
+    line-height: 1.45;
   }
 
   .taglinePlaceholder,

--- a/src/components/ListingCard/__snapshots__/ListingCard.test.js.snap
+++ b/src/components/ListingCard/__snapshots__/ListingCard.test.js.snap
@@ -1,93 +1,634 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ListingCard matches snapshot 1`] = `
-<a
-  aria-label="ListingCard.screenreader.label"
+<div
   class="root"
-  href="/l/listing1-title/listing1"
 >
   <div
-    class="root aspectRatioWrapper"
+    class="imageWrapper"
   >
-    <div
-      class="aspectPadding"
-      style="padding-bottom: 100%;"
+    <a
+      class="imageLink"
+      href="/l/listing1-title/listing1"
     >
       <div
-        class="aspectBox"
+        class="imageContainer"
+      />
+    </a>
+    <button
+      aria-label="SavedListingButton.saveAriaLabel"
+      aria-pressed="false"
+      class="iconRoot saveButton"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="heartIcon"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"
+        />
+      </svg>
+    </button>
+  </div>
+  <a
+    class="infoLink"
+    href="/l/listing1-title/listing1"
+  >
+    <div
+      class="info"
+    >
+      <div
+        class="price"
+        title="55"
+      >
+        <span>
+          ListingCard.price
+        </span>
+      </div>
+      <div
+        class="mainInfo"
       >
         <div
-          style="position: absolute; top: 0px; right: 0px; bottom: 0px; left: 0px;"
-        />
+          class="title"
+        >
+          listing1 title
+        </div>
+        <div
+          class="authorInfo"
+        >
+          <div
+            class="author"
+          >
+            <span>
+              ListingCard.author
+            </span>
+          </div>
+        </div>
       </div>
     </div>
-  </div>
+  </a>
+</div>
+`;
+
+exports[`ListingCard matches snapshot with all badges and no author 1`] = `
+<div
+  class="root"
+>
   <div
-    class="info"
+    class="imageWrapper"
+  >
+    <a
+      class="imageLink"
+      href="/l/listing1-title/listing1"
+    >
+      <div
+        class="imageContainer"
+      >
+        <div
+          class="trustBadges"
+        >
+          <span
+            class="badge"
+          >
+            GOTS
+          </span>
+          <span
+            class="badge"
+          >
+            Non-toxic
+          </span>
+        </div>
+        <div
+          class="conversionBadge"
+        >
+          <span>
+            ListingCard.bestseller
+          </span>
+        </div>
+      </div>
+    </a>
+    <button
+      aria-label="SavedListingButton.saveAriaLabel"
+      aria-pressed="false"
+      class="iconRoot saveButton"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="heartIcon"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"
+        />
+      </svg>
+    </button>
+  </div>
+  <a
+    class="infoLink"
+    href="/l/listing1-title/listing1"
   >
     <div
-      class="price"
-      title="55"
-    >
-      ListingCard.price
-    </div>
-    <div
-      class="mainInfo"
+      class="info"
     >
       <div
-        class="title"
+        class="price"
+        title="55"
       >
-        listing1 title
+        <span>
+          ListingCard.price
+        </span>
       </div>
       <div
-        class="authorInfo"
+        class="mainInfo"
       >
-        ListingCard.author
+        <div
+          class="title"
+        >
+          listing1 title
+        </div>
       </div>
     </div>
+  </a>
+</div>
+`;
+
+exports[`ListingCard matches snapshot with conversion badge (bestseller) 1`] = `
+<div
+  class="root"
+>
+  <div
+    class="imageWrapper"
+  >
+    <a
+      class="imageLink"
+      href="/l/listing1-title/listing1"
+    >
+      <div
+        class="imageContainer"
+      >
+        <div
+          class="conversionBadge"
+        >
+          <span>
+            ListingCard.bestseller
+          </span>
+        </div>
+      </div>
+    </a>
+    <button
+      aria-label="SavedListingButton.saveAriaLabel"
+      aria-pressed="false"
+      class="iconRoot saveButton"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="heartIcon"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"
+        />
+      </svg>
+    </button>
   </div>
-</a>
+  <a
+    class="infoLink"
+    href="/l/listing1-title/listing1"
+  >
+    <div
+      class="info"
+    >
+      <div
+        class="price"
+        title="55"
+      >
+        <span>
+          ListingCard.price
+        </span>
+      </div>
+      <div
+        class="mainInfo"
+      >
+        <div
+          class="title"
+        >
+          listing1 title
+        </div>
+        <div
+          class="authorInfo"
+        >
+          <div
+            class="brandName"
+          >
+            <span>
+              ListingCard.brand
+            </span>
+          </div>
+          <div
+            class="author"
+          >
+            <span>
+              ListingCard.author
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </a>
+</div>
+`;
+
+exports[`ListingCard matches snapshot with conversion badge (low stock) 1`] = `
+<div
+  class="root"
+>
+  <div
+    class="imageWrapper"
+  >
+    <a
+      class="imageLink"
+      href="/l/listing1-title/listing1"
+    >
+      <div
+        class="imageContainer"
+      >
+        <div
+          class="conversionBadge urgencyBadge"
+        >
+          <span>
+            ListingCard.lowStock
+          </span>
+        </div>
+      </div>
+    </a>
+    <button
+      aria-label="SavedListingButton.saveAriaLabel"
+      aria-pressed="false"
+      class="iconRoot saveButton"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="heartIcon"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"
+        />
+      </svg>
+    </button>
+  </div>
+  <a
+    class="infoLink"
+    href="/l/listing1-title/listing1"
+  >
+    <div
+      class="info"
+    >
+      <div
+        class="price"
+        title="55"
+      >
+        <span>
+          ListingCard.price
+        </span>
+      </div>
+      <div
+        class="mainInfo"
+      >
+        <div
+          class="title"
+        >
+          listing1 title
+        </div>
+        <div
+          class="authorInfo"
+        >
+          <div
+            class="brandName"
+          >
+            <span>
+              ListingCard.brand
+            </span>
+          </div>
+          <div
+            class="author"
+          >
+            <span>
+              ListingCard.author
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </a>
+</div>
+`;
+
+exports[`ListingCard matches snapshot with trust badges 1`] = `
+<div
+  class="root"
+>
+  <div
+    class="imageWrapper"
+  >
+    <a
+      class="imageLink"
+      href="/l/listing1-title/listing1"
+    >
+      <div
+        class="imageContainer"
+      >
+        <div
+          class="trustBadges"
+        >
+          <span
+            class="badge"
+          >
+            GOTS
+          </span>
+          <span
+            class="badge"
+          >
+            BPA Free
+          </span>
+        </div>
+      </div>
+    </a>
+    <button
+      aria-label="SavedListingButton.saveAriaLabel"
+      aria-pressed="false"
+      class="iconRoot saveButton"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="heartIcon"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"
+        />
+      </svg>
+    </button>
+  </div>
+  <a
+    class="infoLink"
+    href="/l/listing1-title/listing1"
+  >
+    <div
+      class="info"
+    >
+      <div
+        class="price"
+        title="55"
+      >
+        <span>
+          ListingCard.price
+        </span>
+      </div>
+      <div
+        class="mainInfo"
+      >
+        <div
+          class="title"
+        >
+          listing1 title
+        </div>
+        <div
+          class="authorInfo"
+        >
+          <div
+            class="brandName"
+          >
+            <span>
+              ListingCard.brand
+            </span>
+          </div>
+          <div
+            class="author"
+          >
+            <span>
+              ListingCard.author
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </a>
+</div>
+`;
+
+exports[`ListingCard matches snapshot without author info 1`] = `
+<div
+  class="root"
+>
+  <div
+    class="imageWrapper"
+  >
+    <a
+      class="imageLink"
+      href="/l/listing1-title/listing1"
+    >
+      <div
+        class="imageContainer"
+      />
+    </a>
+    <button
+      aria-label="SavedListingButton.saveAriaLabel"
+      aria-pressed="false"
+      class="iconRoot saveButton"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="heartIcon"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"
+        />
+      </svg>
+    </button>
+  </div>
+  <a
+    class="infoLink"
+    href="/l/listing1-title/listing1"
+  >
+    <div
+      class="info"
+    >
+      <div
+        class="price"
+        title="55"
+      >
+        <span>
+          ListingCard.price
+        </span>
+      </div>
+      <div
+        class="mainInfo"
+      >
+        <div
+          class="title"
+        >
+          listing1 title
+        </div>
+      </div>
+    </div>
+  </a>
+</div>
 `;
 
 exports[`ListingCard matches snapshot without price 1`] = `
-<a
-  aria-label="listing1 title"
+<div
   class="root"
-  href="/l/listing1-title/listing1"
 >
   <div
-    class="root aspectRatioWrapper"
+    class="imageWrapper"
   >
-    <div
-      class="aspectPadding"
-      style="padding-bottom: 100%;"
+    <a
+      class="imageLink"
+      href="/l/listing1-title/listing1"
     >
       <div
-        class="aspectBox"
+        class="imageContainer"
+      />
+    </a>
+    <button
+      aria-label="SavedListingButton.saveAriaLabel"
+      aria-pressed="false"
+      class="iconRoot saveButton"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="heartIcon"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"
+        />
+      </svg>
+    </button>
+  </div>
+  <a
+    class="infoLink"
+    href="/l/listing1-title/listing1"
+  >
+    <div
+      class="info"
+    >
+      <div
+        class="mainInfo"
       >
         <div
-          style="position: absolute; top: 0px; right: 0px; bottom: 0px; left: 0px;"
-        />
+          class="title"
+        >
+          listing1 title
+        </div>
+        <div
+          class="authorInfo"
+        >
+          <div
+            class="author"
+          >
+            <span>
+              ListingCard.author
+            </span>
+          </div>
+        </div>
       </div>
     </div>
-  </div>
+  </a>
+</div>
+`;
+
+exports[`ListingCard variant pill matches snapshot with variant pill 1`] = `
+<div
+  class="root"
+>
   <div
-    class="info"
+    class="imageWrapper"
   >
-    <div
-      class="mainInfo"
+    <a
+      class="imageLink"
+      href="/l/listing1-title/listing1"
     >
       <div
-        class="title"
+        class="imageContainer"
+      />
+    </a>
+    <button
+      aria-label="SavedListingButton.saveAriaLabel"
+      aria-pressed="false"
+      class="iconRoot saveButton"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="heartIcon"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
       >
-        listing1 title
+        <path
+          d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"
+        />
+      </svg>
+    </button>
+  </div>
+  <a
+    class="infoLink"
+    href="/l/listing1-title/listing1"
+  >
+    <div
+      class="info"
+    >
+      <div
+        class="price"
+        title="55"
+      >
+        <span>
+          ListingCard.price
+        </span>
       </div>
       <div
-        class="authorInfo"
+        class="variantPill"
       >
-        ListingCard.author
+        4 variants
+      </div>
+      <div
+        class="mainInfo"
+      >
+        <div
+          class="title"
+        >
+          listing1 title
+        </div>
+        <div
+          class="authorInfo"
+        >
+          <div
+            class="author"
+          >
+            <span>
+              ListingCard.author
+            </span>
+          </div>
+        </div>
       </div>
     </div>
-  </div>
-</a>
+  </a>
+</div>
 `;

--- a/src/components/ProductCarousel/ProductCarousel.js
+++ b/src/components/ProductCarousel/ProductCarousel.js
@@ -60,14 +60,14 @@ const ProductCarousel = ({
           ? [1, 2, 3, 4].map(i => (
               <div key={i} className={`${css.card} ${css.skeleton}`} />
             ))
-          : listingsWithImages.map((listing, index) => (
+          : listingsWithImages.map((listing) => (
               <div key={listing.id.uuid} className={css.card}>
                 <ListingCard
                   listing={listing}
                   showAuthorInfo={false}
                   showTrustBadges={true}
                   showConversionBadges={true}
-                  isBestseller={index === 0}
+                  isBestseller={listing.attributes?.publicData?.isBestseller || false}
                   renderSizes="(max-width: 639px) 50vw, (max-width: 1023px) 33vw, 25vw"
                 />
               </div>

--- a/src/components/ProductCarousel/ProductCarousel.test.js
+++ b/src/components/ProductCarousel/ProductCarousel.test.js
@@ -1,0 +1,149 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { IntlProvider } from 'react-intl';
+import '@testing-library/jest-dom';
+
+jest.mock('../../routing/routeConfiguration', () => []);
+
+jest.mock('../../components', () => ({
+  NamedLink: ({ children, className }) => <a className={className}>{children}</a>,
+  ListingCard: ({ listing, isBestseller }) => (
+    <div
+      data-testid="listing-card"
+      data-id={listing?.id?.uuid}
+      data-is-bestseller={String(!!isBestseller)}
+    />
+  ),
+}));
+
+import ProductCarousel from './ProductCarousel';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const makeListing = (id, { isBestseller = false } = {}) => ({
+  id: { uuid: id },
+  type: 'listing',
+  attributes: {
+    title: `Product ${id}`,
+    publicData: { isBestseller },
+  },
+  images: [{ id: { uuid: `img-${id}` } }],
+});
+
+const renderCarousel = (props = {}) =>
+  render(
+    <MemoryRouter>
+      <IntlProvider locale="en" messages={{}}>
+        <ProductCarousel title="Test Carousel" {...props} />
+      </IntlProvider>
+    </MemoryRouter>
+  );
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('ProductCarousel', () => {
+  describe('isBestseller badge', () => {
+    it('passes isBestseller=true only when publicData.isBestseller is true', () => {
+      const listings = [
+        makeListing('a', { isBestseller: false }),
+        makeListing('b', { isBestseller: true }),
+        makeListing('c', { isBestseller: false }),
+      ];
+      renderCarousel({ listings });
+
+      const cards = screen.getAllByTestId('listing-card');
+      expect(cards[0]).toHaveAttribute('data-is-bestseller', 'false');
+      expect(cards[1]).toHaveAttribute('data-is-bestseller', 'true');
+      expect(cards[2]).toHaveAttribute('data-is-bestseller', 'false');
+    });
+
+    it('does not mark the first-position listing as bestseller based on index alone', () => {
+      const listings = [makeListing('a'), makeListing('b'), makeListing('c')];
+      renderCarousel({ listings });
+
+      screen.getAllByTestId('listing-card').forEach(card => {
+        expect(card).toHaveAttribute('data-is-bestseller', 'false');
+      });
+    });
+
+    it('passes isBestseller=false when publicData.isBestseller is explicitly false', () => {
+      const listings = [
+        makeListing('a', { isBestseller: false }),
+        makeListing('b', { isBestseller: false }),
+      ];
+      renderCarousel({ listings });
+
+      screen.getAllByTestId('listing-card').forEach(card => {
+        expect(card).toHaveAttribute('data-is-bestseller', 'false');
+      });
+    });
+
+    it('passes isBestseller=false when publicData.isBestseller is absent', () => {
+      const listing = {
+        id: { uuid: 'x' },
+        type: 'listing',
+        attributes: { title: 'No flag', publicData: {} },
+        images: [{ id: { uuid: 'img-x' } }],
+      };
+      renderCarousel({ listings: [listing, makeListing('y')] });
+
+      expect(screen.getAllByTestId('listing-card')[0]).toHaveAttribute(
+        'data-is-bestseller',
+        'false'
+      );
+    });
+  });
+
+  describe('visibility', () => {
+    it('renders nothing when fewer than minItems listings have images', () => {
+      const { container } = renderCarousel({ listings: [makeListing('a')] });
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('renders nothing when listings array is empty', () => {
+      const { container } = renderCarousel({ listings: [] });
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('renders nothing when no listings have images', () => {
+      const noImageListings = [
+        { id: { uuid: 'a' }, attributes: { title: 'A', publicData: {} }, images: [] },
+        { id: { uuid: 'b' }, attributes: { title: 'B', publicData: {} }, images: [] },
+      ];
+      const { container } = renderCarousel({ listings: noImageListings });
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('renders when at least minItems listings have images', () => {
+      renderCarousel({ listings: [makeListing('a'), makeListing('b')] });
+      expect(screen.getAllByTestId('listing-card')).toHaveLength(2);
+    });
+
+    it('renders loading skeleton when isLoading is true', () => {
+      const { container } = renderCarousel({ listings: [], isLoading: true });
+      expect(container.querySelector('.skeleton')).toBeInTheDocument();
+    });
+  });
+
+  describe('header', () => {
+    it('renders the carousel title', () => {
+      renderCarousel({ listings: [makeListing('a'), makeListing('b')] });
+      expect(screen.getByText('Test Carousel')).toBeInTheDocument();
+    });
+
+    it('renders the View All link when viewAllLinkName is provided', () => {
+      renderCarousel({
+        listings: [makeListing('a'), makeListing('b')],
+        viewAllLinkName: 'SearchPage',
+        viewAllLinkSearch: '?foo=bar',
+      });
+      expect(screen.getByText(/View All/i)).toBeInTheDocument();
+    });
+
+    it('omits the View All link when viewAllLinkName is not provided', () => {
+      renderCarousel({ listings: [makeListing('a'), makeListing('b')] });
+      expect(screen.queryByText(/View All/i)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/config/settingsCurrency.js
+++ b/src/config/settingsCurrency.js
@@ -193,13 +193,12 @@ export const currencyFormatting = (currency, options) => {
     );
   }
 
-  return subUnitDivisors[currency] === 1
+  return subUnitDivisors[currency] === 1 || currency === 'USD'
     ? {
         style: 'currency',
         currency,
         currencyDisplay: 'symbol',
         useGrouping: true,
-        // If the currency is not using subunits (like JPY), remove fractions.
         minimumFractionDigits: 0,
         maximumFractionDigits: 0,
       }

--- a/src/containers/BrandsPage/BrandsPage.duck.js
+++ b/src/containers/BrandsPage/BrandsPage.duck.js
@@ -327,7 +327,6 @@ export const fetchFeaturedBrands = () => (dispatch, getState, sdk) => {
   const featuredIds = getRandomBrandIds(6);
 
   if (featuredIds.length === 0) {
-    // No featured brands
     dispatch(fetchFeaturedBrandsSuccess([]));
     return Promise.resolve();
   }

--- a/src/containers/MelaHomePage/sections/CategoryShowcase/CategoryShowcase.js
+++ b/src/containers/MelaHomePage/sections/CategoryShowcase/CategoryShowcase.js
@@ -263,14 +263,14 @@ export const OccasionStrip = ({ config, additionalQueryParams = {} }) => {
                 </div>
               ) : (
                 <div className={css.productCarousel}>
-                  {products.map((listing, i) => (
+                  {products.map((listing) => (
                     <div key={listing.id.uuid} className={css.carouselCard}>
                       <ListingCard
                         listing={listing}
                         showAuthorInfo={false}
                         showTrustBadges={true}
                         showConversionBadges={true}
-                        isBestseller={i === 0}
+                        isBestseller={listing.attributes?.publicData?.isBestseller || false}
                         renderSizes="(max-width: 639px) 50vw, (max-width: 1023px) 33vw, 25vw"
                       />
                     </div>

--- a/src/containers/MelaHomePage/sections/CategoryShowcase/CategoryShowcase.test.js
+++ b/src/containers/MelaHomePage/sections/CategoryShowcase/CategoryShowcase.test.js
@@ -48,8 +48,12 @@ jest.mock('../../../../components', () => ({
         {title}
       </div>
     ),
-  ListingCard: ({ listing }) => (
-    <div data-testid="listing-card" data-id={listing?.id?.uuid}>
+  ListingCard: ({ listing, isBestseller }) => (
+    <div
+      data-testid="listing-card"
+      data-id={listing?.id?.uuid}
+      data-is-bestseller={String(!!isBestseller)}
+    >
       {listing?.attributes?.title}
     </div>
   ),
@@ -86,14 +90,21 @@ const emptyQueryResponse = () => ({
   data: { data: [], included: [], meta: {} },
 });
 
-/** Minimal listing. occasionTag populates publicData.occasion for OccasionStrip's client-side filter. */
-const makeListing = (id, { occasionTag = null } = {}) => ({
+/**
+ * Minimal listing.
+ * occasionTag populates publicData.occasion for OccasionStrip's client-side filter.
+ * isBestseller populates publicData.isBestseller for the badge.
+ */
+const makeListing = (id, { occasionTag = null, isBestseller = false } = {}) => ({
   id: { uuid: id },
   type: 'listing',
   attributes: {
     title: `Product ${id}`,
     price: { amount: 1500, currency: 'USD' },
-    publicData: occasionTag ? { occasion: occasionTag } : {},
+    publicData: {
+      ...(occasionTag ? { occasion: occasionTag } : {}),
+      ...(isBestseller ? { isBestseller: true } : {}),
+    },
   },
 });
 
@@ -123,7 +134,7 @@ describe('CategoryShowcase', () => {
   it('renders the section sub-heading', () => {
     renderInContext(<CategoryShowcase />);
     expect(
-      screen.getByText(/Baby, fashion, home, jewelry and wellness/i)
+      screen.getByText(/Baby, fashion, home, jewelry, wellness and art/i)
     ).toBeInTheDocument();
   });
 
@@ -161,9 +172,8 @@ const renderAndWaitForLoad = async (ui, config = {}) => {
 };
 
 // ── AllCategoryCarousels ──────────────────────────────────────────────────────
-// All 7 top-level categories (Baby & Kids, Fashion, Home & Kitchen, Jewelry &
-// Accessories, Beauty & Wellness, Food & Gourmet, Art & Craft) are fetched by
-// a single carousel component using ALL_CATEGORIES, all with perPage: 24 + pickRandom.
+// 6 top-level categories fetched by a single carousel component using ALL_CATEGORIES,
+// all with perPage: 100 + pickBrandDiverse.
 
 describe('AllCategoryCarousels', () => {
   beforeEach(() => {
@@ -172,16 +182,16 @@ describe('AllCategoryCarousels', () => {
     denormalisedEntities.mockReturnValue([]);
   });
 
-  it('queries all 7 categories with perPage: 24', async () => {
+  it('queries all 6 categories with perPage: 100', async () => {
     const calls = await renderAndWaitForLoad(<CategoryShowcase />);
-    const catCalls = calls.filter(([p]) => p.pub_categoryLevel1 && p.perPage === 24);
-    expect(catCalls).toHaveLength(7);
+    const catCalls = calls.filter(([p]) => p.pub_categoryLevel1 && p.perPage === 100);
+    expect(catCalls).toHaveLength(6);
   });
 
-  it('queries Baby-Kids, Fashion, Home-Kitchen, Jewelry-Accessories, Beauty-Wellness, Food-Gourmet, Art-Craft', async () => {
+  it('queries Baby-Kids, Fashion, Home-Kitchen, Jewelry-Accessories, Beauty-Wellness, Art-Craft', async () => {
     const calls = await renderAndWaitForLoad(<CategoryShowcase />);
     const categories = calls
-      .filter(([p]) => p.pub_categoryLevel1 && p.perPage === 24)
+      .filter(([p]) => p.pub_categoryLevel1 && p.perPage === 100)
       .map(([p]) => p.pub_categoryLevel1);
     expect(categories).toEqual(
       expect.arrayContaining([
@@ -190,7 +200,6 @@ describe('AllCategoryCarousels', () => {
         'Home-Kitchen',
         'Jewelry-Accessories',
         'Beauty-Wellness',
-        'Food-Gourmet',
         'Art-Craft',
       ])
     );
@@ -199,7 +208,7 @@ describe('AllCategoryCarousels', () => {
   it('includes images and currentStock in all category queries', async () => {
     const calls = await renderAndWaitForLoad(<CategoryShowcase />);
     calls
-      .filter(([p]) => p.pub_categoryLevel1 && p.perPage === 24)
+      .filter(([p]) => p.pub_categoryLevel1 && p.perPage === 100)
       .forEach(([params]) => {
         expect(params.include).toEqual(expect.arrayContaining(['images', 'currentStock']));
       });
@@ -208,11 +217,11 @@ describe('AllCategoryCarousels', () => {
   it('shows loading carousels while fetching', () => {
     mockQuery.mockReturnValue(new Promise(() => {}));
     renderInContext(<CategoryShowcase />);
-    // AllCategories(7) + AgeNavigation(3) = at least 7 loading carousels
-    expect(screen.getAllByTestId('carousel-loading').length).toBeGreaterThanOrEqual(7);
+    // AllCategories(6) + AgeNavigation(3) = at least 6 loading carousels
+    expect(screen.getAllByTestId('carousel-loading').length).toBeGreaterThanOrEqual(6);
   });
 
-  it('renders all 7 category carousels with correct titles after load', async () => {
+  it('renders all 6 category carousels with correct titles after load', async () => {
     await renderAndWaitForLoad(<CategoryShowcase />);
     const titles = screen.getAllByTestId('product-carousel').map(el => el.getAttribute('data-title'));
     expect(titles).toEqual(
@@ -222,7 +231,6 @@ describe('AllCategoryCarousels', () => {
         'Home & Kitchen',
         'Jewelry & Accessories',
         'Beauty & Wellness',
-        'Food & Gourmet',
         'Art & Craft',
       ])
     );
@@ -238,11 +246,11 @@ describe('AgeNavigation', () => {
     denormalisedEntities.mockReturnValue([]);
   });
 
-  it('queries each age group with perPage: 24', async () => {
+  it('queries each age group with perPage: 100', async () => {
     const calls = await renderAndWaitForLoad(<CategoryShowcase />);
     const ageCalls = calls.filter(([p]) => p.pub_age_group);
     expect(ageCalls).toHaveLength(3);
-    ageCalls.forEach(([params]) => expect(params.perPage).toBe(24));
+    ageCalls.forEach(([params]) => expect(params.perPage).toBe(100));
   });
 
   it('queries newborn, 0_6_months, 6_12_months', async () => {
@@ -271,14 +279,14 @@ describe('OccasionStrip', () => {
     denormalisedEntities.mockReturnValue([]);
   });
 
-  it('queries each occasion with perPage: 18', async () => {
+  it('queries each occasion with perPage: 50', async () => {
     renderInContext(<OccasionStrip />);
 
     await waitFor(() => {
       const calls = mockQuery.mock.calls.filter(([p]) => p.pub_occasion);
       expect(calls).toHaveLength(2);
       calls.forEach(([params]) => {
-        expect(params.perPage).toBe(18);
+        expect(params.perPage).toBe(50);
       });
     });
   });
@@ -392,6 +400,48 @@ describe('OccasionStrip', () => {
         .forEach(([params]) => {
           expect(params.pub_categoryLevel1).toBe('Fashion');
         });
+    });
+  });
+
+  describe('isBestseller badge', () => {
+    it('passes isBestseller=true only when publicData.isBestseller is set', async () => {
+      const listings = [
+        makeListing('g1', { occasionTag: 'gifting', isBestseller: true }),
+        makeListing('g2', { occasionTag: 'gifting' }),
+        makeListing('g3', { occasionTag: 'gifting' }),
+      ];
+
+      denormalisedEntities
+        .mockReturnValueOnce([]) // diwali → hidden
+        .mockReturnValueOnce(listings); // gifting
+
+      renderInContext(<OccasionStrip />);
+
+      await waitFor(() => {
+        const cards = screen.getAllByTestId('listing-card');
+        expect(cards[0]).toHaveAttribute('data-is-bestseller', 'true');
+        expect(cards[1]).toHaveAttribute('data-is-bestseller', 'false');
+        expect(cards[2]).toHaveAttribute('data-is-bestseller', 'false');
+      });
+    });
+
+    it('does not mark the first-position listing as bestseller when publicData.isBestseller is absent', async () => {
+      const listings = [
+        makeListing('g1', { occasionTag: 'gifting' }), // index 0, no isBestseller
+        makeListing('g2', { occasionTag: 'gifting' }),
+      ];
+
+      denormalisedEntities
+        .mockReturnValueOnce([]) // diwali → hidden
+        .mockReturnValueOnce(listings); // gifting
+
+      renderInContext(<OccasionStrip />);
+
+      await waitFor(() => {
+        screen.getAllByTestId('listing-card').forEach(card => {
+          expect(card).toHaveAttribute('data-is-bestseller', 'false');
+        });
+      });
     });
   });
 

--- a/src/containers/MelaHomePage/sections/FeaturedBrandPartners/FeaturedBrandPartners.js
+++ b/src/containers/MelaHomePage/sections/FeaturedBrandPartners/FeaturedBrandPartners.js
@@ -109,12 +109,11 @@ const FeaturedBrandPartners = props => {
           {brandsWithProducts.map(({ brand, products }) => (
             <div key={brand.id.uuid} className={css.carouselCard}>
               <BrandCardHome
-              brand={brand}
-              products={products}
-              showCertifications={false}
-              showTagline={false}
-              showLocation={false}
-            />
+                brand={brand}
+                products={products}
+                showCertifications={false}
+                showLocation={false}
+              />
             </div>
           ))}
           {/* COMMENTED OUT: partner recruitment CTA card

--- a/src/containers/ProfilePage/BrandStorefront.js
+++ b/src/containers/ProfilePage/BrandStorefront.js
@@ -47,11 +47,6 @@ const BrandDataPlaceholder = ({ type, missingFields, isOwner }) => {
       title: 'BrandStorefront.placeholder.certifications.title',
       description: 'BrandStorefront.placeholder.certifications.description',
     },
-    mission: {
-      icon: '🎯',
-      title: 'BrandStorefront.placeholder.mission.title',
-      description: 'BrandStorefront.placeholder.mission.description',
-    },
     products: {
       icon: '📦',
       title: 'BrandStorefront.placeholder.products.title',
@@ -240,7 +235,6 @@ const BrandStorefront = props => {
     certifications = [],
     brandTagline,
     brandStory,
-    brandMission,
     brandLogoUrl,
     brandOrigin,
     brandCity,
@@ -478,18 +472,6 @@ const BrandStorefront = props => {
                 isOwnProfile={isOwnProfile}
               />
             )}
-
-            {/* Brand Mission */}
-            {brandMission ? (
-              <div className={css.brandMission}>
-                <H4 className={css.sectionSubtitle}>
-                  <FormattedMessage id="BrandStorefront.ourMission" />
-                </H4>
-                <p className={css.missionContent}>{brandMission}</p>
-              </div>
-            ) : isOwnProfile ? (
-              <BrandDataPlaceholder type="mission" isOwner={isOwnProfile} />
-            ) : null}
 
             {/* Certifications Detail */}
             {hasCertifications ? (

--- a/src/containers/SearchPage/SearchResultsPanel/SearchResultsPanel.test.js
+++ b/src/containers/SearchPage/SearchResultsPanel/SearchResultsPanel.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import '@testing-library/jest-dom';
 import { renderWithProviders as render, testingLibrary } from '../../../util/testHelpers';
-import { createListing } from '../../../util/testData';
+import { createListing, fakeIntl } from '../../../util/testData';
 import SearchResultsPanel from './SearchResultsPanel';
 
 const { screen } = testingLibrary;
@@ -229,6 +229,7 @@ describe('SearchResultsPanel', () => {
           search={{}}
           setActiveListing={mockSetActiveListing}
           isMapVariant={false}
+          intl={fakeIntl}
         />
       );
 

--- a/src/util/currency.test.js
+++ b/src/util/currency.test.js
@@ -12,6 +12,7 @@ import {
   truncateToSubUnitPrecision,
   formatMoney,
 } from './currency';
+import { currencyFormatting } from '../config/settingsCurrency';
 
 const { Money } = sdkTypes;
 
@@ -246,5 +247,50 @@ describe('currency utils', () => {
     // No test for that actual formatting for now. It depends on the
     // locale, and it doesn't really make sense to test the fake intl
     // implementation in the tests.
+  });
+});
+
+describe('currencyFormatting', () => {
+  it('returns 0 fraction digits for USD (whole-dollar display)', () => {
+    const opts = currencyFormatting('USD');
+    expect(opts.minimumFractionDigits).toBe(0);
+    expect(opts.maximumFractionDigits).toBe(0);
+  });
+
+  it('returns 2 fraction digits for EUR', () => {
+    const opts = currencyFormatting('EUR');
+    expect(opts.minimumFractionDigits).toBe(2);
+    expect(opts.maximumFractionDigits).toBe(2);
+  });
+
+  it('returns 2 fraction digits for GBP', () => {
+    const opts = currencyFormatting('GBP');
+    expect(opts.minimumFractionDigits).toBe(2);
+    expect(opts.maximumFractionDigits).toBe(2);
+  });
+
+  it('returns 0 fraction digits for JPY (no subunits, subUnitDivisor === 1)', () => {
+    const opts = currencyFormatting('JPY');
+    expect(opts.minimumFractionDigits).toBe(0);
+    expect(opts.maximumFractionDigits).toBe(0);
+  });
+
+  it('returns currency style for all currencies', () => {
+    expect(currencyFormatting('USD').style).toBe('currency');
+    expect(currencyFormatting('EUR').style).toBe('currency');
+    expect(currencyFormatting('JPY').style).toBe('currency');
+  });
+
+  it('returns the currency symbol display mode', () => {
+    expect(currencyFormatting('USD').currencyDisplay).toBe('symbol');
+    expect(currencyFormatting('EUR').currencyDisplay).toBe('symbol');
+  });
+
+  it('throws for an unsupported currency by default', () => {
+    expect(() => currencyFormatting('XYZ')).toThrow(/Configuration missing for currency/);
+  });
+
+  it('does not throw for unsupported currency when enforceSupportedCurrencies is false', () => {
+    expect(() => currencyFormatting('XYZ', { enforceSupportedCurrencies: false })).not.toThrow();
   });
 });


### PR DESCRIPTION
Surfaces Mela-authored brand taglines and stories on brand cards across the homepage and brands directory, sourced from Sharetribe's native bio field.

  - BrandCard (mini): restructured header to give tagline its own text column; tagline now wraps freely alongside logo instead of being squeezed into a single line
  - BrandCardHome: removed 80-char JS truncation and CSS single-line clamp; tagline wraps naturally to 2–3 lines
  - FeaturedBrandPartners (homepage): removed showTagline={false} so brand descriptions appear in the homepage carousel
  - BrandStorefront: removed brandMission section — brand story in the About tab now covers both story and ethos in a single field
  - Both card components read from profile.bio (first sentence as tagline, full bio as About tab story), with publicData.brandTagline as an optional override