### PR TITLE
feat: bestseller carousel refactor, swipe UX, and trust sheet delay

### DIFF
--- a/src/components/ListingCard/ListingCard.js
+++ b/src/components/ListingCard/ListingCard.js
@@ -391,11 +391,6 @@ export const ListingCard = props => {
             intl={intl}
             listingTypeConfig={foundListingTypeConfig}
           />
-          {publicData?.variantCount > 1 && (
-            <div className={css.variantPill}>
-              {publicData.variantCount} variants
-            </div>
-          )}
           <div className={css.mainInfo}>
             {showListingImage && (
               <div className={css.title}>
@@ -403,6 +398,11 @@ export const ListingCard = props => {
                   longWordMinLength: MIN_LENGTH_FOR_LONG_WORDS,
                   longWordClass: css.longWord,
                 })}
+              </div>
+            )}
+            {publicData?.variantCount > 1 && (
+              <div className={css.variantPill}>
+                {publicData.variantCount} variants
               </div>
             )}
             {showAuthorInfo ? (

--- a/src/components/RedirectTrustSheet/RedirectTrustSheet.js
+++ b/src/components/RedirectTrustSheet/RedirectTrustSheet.js
@@ -40,6 +40,7 @@ const RedirectTrustSheet = ({ isOpen, brandName, productUrl, isVerified, onConti
   const [freeText, setFreeText] = useState('');
   const [email, setEmail] = useState('');
   const [emailError, setEmailError] = useState(false);
+  const [isButtonDisabled, setIsButtonDisabled] = useState(true);
   const textareaRef = useRef(null);
 
   // Reset internal state each time the sheet opens
@@ -50,8 +51,17 @@ const RedirectTrustSheet = ({ isOpen, brandName, productUrl, isVerified, onConti
       setFreeText('');
       setEmail('');
       setEmailError(false);
+      setIsButtonDisabled(true);
     }
   }, [isOpen]);
+
+  // 1.5-second activation delay for Continue button on first show
+  useEffect(() => {
+    if (isOpen && isButtonDisabled) {
+      const timer = setTimeout(() => setIsButtonDisabled(false), 1500);
+      return () => clearTimeout(timer);
+    }
+  }, [isOpen, isButtonDisabled]);
 
   // Focus textarea when expanded
   useEffect(() => {
@@ -208,7 +218,11 @@ const RedirectTrustSheet = ({ isOpen, brandName, productUrl, isVerified, onConti
 
         {/* ── Continue button — always visible ── */}
         <div className={css.ctaRow}>
-          <button className={css.continueBtn} onClick={handleContinue}>
+          <button
+            className={[css.continueBtn, isButtonDisabled ? css.continueBtnDisabled : ''].filter(Boolean).join(' ')}
+            onClick={handleContinue}
+            disabled={isButtonDisabled}
+          >
             {intl.formatMessage({ id: 'RedirectTrustSheet.continue' }, { brand: brandName })}
           </button>
           <button className={css.dismissBtn} onClick={onClose} aria-label={intl.formatMessage({ id: isExpanded ? 'RedirectTrustSheet.dismissLabelExpanded' : 'RedirectTrustSheet.dismissLabel' })}>

--- a/src/components/RedirectTrustSheet/RedirectTrustSheet.module.css
+++ b/src/components/RedirectTrustSheet/RedirectTrustSheet.module.css
@@ -325,6 +325,32 @@
   background: var(--marketplaceColorDark, #1a1744);
 }
 
+.continueBtnDisabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  filter: saturate(0.6);
+  animation: activating 1.5s ease-out;
+}
+
+.continueBtnDisabled:hover {
+  background: var(--marketplaceColor, #262261);
+  opacity: 0.5;
+}
+
+@keyframes activating {
+  0% {
+    opacity: 0.5;
+    box-shadow: 0 0 0 0 rgba(38, 34, 97, 0.2);
+  }
+  50% {
+    box-shadow: 0 0 0 3px rgba(38, 34, 97, 0.12);
+  }
+  100% {
+    opacity: 0.5;
+    box-shadow: 0 0 0 0 rgba(38, 34, 97, 0);
+  }
+}
+
 .dismissBtn {
   background: none;
   border: 1.5px solid #e2e8f0;

--- a/src/components/RedirectTrustSheet/RedirectTrustSheet.test.js
+++ b/src/components/RedirectTrustSheet/RedirectTrustSheet.test.js
@@ -1,15 +1,40 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import { IntlProvider } from 'react-intl';
 import RedirectTrustSheet from './RedirectTrustSheet';
 import * as sentimentCapture from '../../util/sentimentCapture';
 
-// Minimal i18n wrapper — uses key as fallback so tests are resilient to copy changes
-const TestWrapper = ({ children }) => (
-  <IntlProvider locale="en" messages={{}}>
-    {children}
-  </IntlProvider>
-);
+// Minimal i18n wrapper with stubs for required messages
+const TestWrapper = ({ children }) => {
+  const messages = {
+    'RedirectTrustSheet.heading': 'Shop on {brand}',
+    'RedirectTrustSheet.trustCheckout': 'Secure Shopify checkout',
+    'RedirectTrustSheet.trustShipping': 'Ships to the US',
+    'RedirectTrustSheet.trustReturns': 'Easy returns from {brand}',
+    'RedirectTrustSheet.sentimentPrompt': 'How likely to recommend?',
+    'RedirectTrustSheet.thumbsUp': 'Thumbs up',
+    'RedirectTrustSheet.thumbsDown': 'Thumbs down',
+    'RedirectTrustSheet.promptThumbsUp': 'What did you like?',
+    'RedirectTrustSheet.promptThumbsDown': 'What could be better?',
+    'RedirectTrustSheet.textareaPlaceholder': 'Tell us more...',
+    'RedirectTrustSheet.emailLabel': 'Email (optional)',
+    'RedirectTrustSheet.emailPlaceholder': 'your@email.com',
+    'RedirectTrustSheet.emailError': 'Please enter a valid email address',
+    'RedirectTrustSheet.submit': 'Send feedback',
+    'RedirectTrustSheet.skip': 'Skip',
+    'RedirectTrustSheet.thankYou': 'Thanks for the feedback!',
+    'RedirectTrustSheet.continue': 'Continue to {brand}',
+    'RedirectTrustSheet.dismissLabel': 'Not now',
+    'RedirectTrustSheet.dismissLabelExpanded': 'Close',
+    'RedirectTrustSheet.ariaLabel': 'Shop brand routing',
+  };
+  return (
+    <IntlProvider locale="en" messages={messages}>
+      {children}
+    </IntlProvider>
+  );
+};
 
 const defaultProps = {
   isOpen: true,
@@ -58,10 +83,17 @@ describe('RedirectTrustSheet', () => {
   });
 
   it('calls onContinue with productUrl when CTA is clicked', () => {
+    jest.useFakeTimers();
     render(<TestWrapper><RedirectTrustSheet {...defaultProps} /></TestWrapper>);
-    fireEvent.click(screen.getByRole('button', { name: /Continue to Aagghhoo/i }));
+    const continueBtn = screen.getByRole('button', { name: /Continue to Aagghhoo/i });
+    // button starts disabled, so advance time to enable it
+    act(() => {
+      jest.advanceTimersByTime(1500);
+    });
+    fireEvent.click(continueBtn);
     expect(defaultProps.onContinue).toHaveBeenCalledWith('https://aagghhoo.com/product/1');
     expect(defaultProps.onClose).toHaveBeenCalled();
+    jest.useRealTimers();
   });
 
   it('calls onClose when dismiss button is clicked', () => {
@@ -82,5 +114,41 @@ describe('RedirectTrustSheet', () => {
     fireEvent.click(screen.getByRole('button', { name: /Send feedback/i }));
     expect(screen.getByText(/Please enter a valid email address/i)).toBeInTheDocument();
     expect(sentimentCapture.postSentiment).toHaveBeenCalledTimes(1); // only the thumbs post, not the submit
+  });
+
+  it('disables Continue button on first show (1.5s delay)', () => {
+    render(<TestWrapper><RedirectTrustSheet {...defaultProps} /></TestWrapper>);
+    const continueBtn = screen.getByRole('button', { name: /Continue to Aagghhoo/i });
+    // button should be disabled initially
+    expect(continueBtn).toBeDisabled();
+  });
+
+  it('enables Continue button after 1.5 seconds', () => {
+    jest.useFakeTimers();
+    render(<TestWrapper><RedirectTrustSheet {...defaultProps} /></TestWrapper>);
+    const continueBtn = screen.getByRole('button', { name: /Continue to Aagghhoo/i });
+    expect(continueBtn).toBeDisabled();
+    // advance time by 1500ms
+    act(() => {
+      jest.advanceTimersByTime(1500);
+    });
+    // button should be enabled after the delay
+    expect(continueBtn).not.toBeDisabled();
+    jest.useRealTimers();
+  });
+
+  it('resets button disabled state when sheet closes and reopens', async () => {
+    const { rerender } = render(
+      <TestWrapper><RedirectTrustSheet {...defaultProps} /></TestWrapper>
+    );
+    const continueBtn = screen.getByRole('button', { name: /Continue to Aagghhoo/i });
+    expect(continueBtn).toBeDisabled();
+    // close the sheet
+    rerender(<TestWrapper><RedirectTrustSheet {...defaultProps} isOpen={false} /></TestWrapper>);
+    // reopen it
+    rerender(<TestWrapper><RedirectTrustSheet {...defaultProps} isOpen={true} /></TestWrapper>);
+    // button should be disabled again
+    const reopenedBtn = screen.getByRole('button', { name: /Continue to Aagghhoo/i });
+    expect(reopenedBtn).toBeDisabled();
   });
 });

--- a/src/containers/BrandsPage/BrandsPage.duck.js
+++ b/src/containers/BrandsPage/BrandsPage.duck.js
@@ -1,4 +1,5 @@
 import { storableError } from '../../util/errors';
+import { pickRandom } from '../../util/listings';
 import { addMarketplaceEntities } from '../../ducks/marketplaceData.duck';
 import {
   getRandomBrandIds,
@@ -8,6 +9,30 @@ import {
   getBrandCategory,
 } from '../../config/configBrands';
 import { denormalisedEntities } from '../../util/data';
+
+// ================ Utility Functions ================ //
+
+const fetchBestsellerListingsForBrand = (sdk, brandId) => {
+  return sdk.listings
+    .query({
+      'fields.listing': ['title', 'price', 'publicData', 'images'],
+      'fields.image': ['variants.square-small', 'variants.square-small2x'],
+      'imageVariant.square-small': 'w:400;h:300;fit:crop',
+      'imageVariant.square-small2x': 'w:800;h:600;fit:crop',
+      include: ['author', 'images'],
+      author: brandId,
+      pub_isBestseller: true,
+      perPage: 20,
+    })
+    .then(response => {
+      const { data = [], included = [] } = response.data || {};
+      return { data, included };
+    })
+    .catch(error => {
+      console.warn(`Failed to fetch bestseller listings for brand ${brandId}:`, error);
+      return { data: [], included: [] };
+    });
+};
 
 // ================ Action types ================ //
 
@@ -19,6 +44,8 @@ export const FETCH_FEATURED_BRANDS_REQUEST = 'app/BrandsPage/FETCH_FEATURED_BRAN
 export const FETCH_FEATURED_BRANDS_SUCCESS = 'app/BrandsPage/FETCH_FEATURED_BRANDS_SUCCESS';
 export const FETCH_FEATURED_BRANDS_ERROR = 'app/BrandsPage/FETCH_FEATURED_BRANDS_ERROR';
 
+export const SET_BESTSELLER_PRODUCTS = 'app/BrandsPage/SET_BESTSELLER_PRODUCTS';
+
 // ================ Reducer ================ //
 
 const initialState = {
@@ -29,6 +56,7 @@ const initialState = {
   fetchBrandsError: null,
   fetchFeaturedBrandsInProgress: false,
   fetchFeaturedBrandsError: null,
+  bestsellerProductsByBrand: {}, // Map of brandId -> { data: [...], included: [...] }
 };
 
 export default function brandsPageReducer(state = initialState, action = {}) {
@@ -81,6 +109,12 @@ export default function brandsPageReducer(state = initialState, action = {}) {
         fetchFeaturedBrandsError: payload,
       };
 
+    case SET_BESTSELLER_PRODUCTS:
+      return {
+        ...state,
+        bestsellerProductsByBrand: payload,
+      };
+
     default:
       return state;
   }
@@ -116,6 +150,11 @@ export const fetchFeaturedBrandsError = error => ({
   type: FETCH_FEATURED_BRANDS_ERROR,
   payload: error,
   error: true,
+});
+
+export const setBestsellerProducts = bestsellersByBrand => ({
+  type: SET_BESTSELLER_PRODUCTS,
+  payload: bestsellersByBrand,
 });
 
 // ================ Thunks ================ //
@@ -170,6 +209,12 @@ export const fetchBrands = (params = {}) => (dispatch, getState, sdk) => {
       })
   );
 
+  // Fetch bestseller products for each brand in parallel
+  const bestsellerPromises = brandIds.map(brandId =>
+    fetchBestsellerListingsForBrand(sdk, brandId)
+      .then(result => ({ brandId, ...result }))
+  );
+
   // Batch fetch ALL featured products for these brands in ONE query (performance optimization)
   const allProductIds = getFeaturedProductIds(brandIds);
   const productsPromise =
@@ -195,11 +240,23 @@ export const fetchBrands = (params = {}) => (dispatch, getState, sdk) => {
           })
       : Promise.resolve({ data: [], included: [] });
 
-  // Wait for both brands and products to fetch in parallel
-  return Promise.all([Promise.all(brandPromises), productsPromise])
-    .then(([brandResponses, productsResponse]) => {
+  // Wait for brands, bestsellers, and configured products to fetch in parallel
+  return Promise.all([Promise.all(brandPromises), Promise.all(bestsellerPromises), productsPromise])
+    .then(([brandResponses, bestsellerResponses, configProductsResponse]) => {
       // Filter out failed brand requests
       const validResponses = brandResponses.filter(r => r !== null);
+
+      // Build bestseller products map by brand ID
+      const bestsellersByBrand = {};
+      (bestsellerResponses || []).forEach(({ brandId, data = [], included = [] }) => {
+        if (data.length > 0) {
+          // Randomize and select up to 4 bestseller products
+          bestsellersByBrand[brandId] = {
+            data: pickRandom(data, 4),
+            included,
+          };
+        }
+      });
 
       // Combine all responses and filter out any invalid user objects
       const users = validResponses
@@ -260,12 +317,12 @@ export const fetchBrands = (params = {}) => (dispatch, getState, sdk) => {
 
       const validIncluded = included.filter(e => e !== undefined && e !== null);
 
-      // Process products response
-      const products = productsResponse.data || [];
-      const productImages = productsResponse.included || [];
+      // Process configured products response
+      const configProducts = configProductsResponse.data || [];
+      const configProductImages = configProductsResponse.included || [];
 
-      // Filter valid products
-      const validProducts = products.filter(
+      // Filter valid configured products
+      const validConfigProducts = configProducts.filter(
         listing =>
           listing &&
           typeof listing === 'object' &&
@@ -274,7 +331,7 @@ export const fetchBrands = (params = {}) => (dispatch, getState, sdk) => {
           listing.type === 'listing'
       );
 
-      const validProductImages = productImages.filter(
+      const validConfigProductImages = configProductImages.filter(
         entity =>
           entity &&
           typeof entity === 'object' &&
@@ -283,9 +340,35 @@ export const fetchBrands = (params = {}) => (dispatch, getState, sdk) => {
           entity.type === 'image'
       );
 
-      // Combine all entities (users + products + images)
-      const allEntities = [...validUsers, ...validProducts];
-      const allIncluded = [...validIncluded, ...validProductImages];
+      // Process bestseller products and include them
+      let bestsellerProducts = [];
+      let bestsellerImages = [];
+      Object.values(bestsellersByBrand).forEach(({ data = [], included = [] }) => {
+        bestsellerProducts = bestsellerProducts.concat(
+          data.filter(
+            listing =>
+              listing &&
+              typeof listing === 'object' &&
+              listing.id &&
+              listing.id.uuid &&
+              listing.type === 'listing'
+          )
+        );
+        bestsellerImages = bestsellerImages.concat(
+          included.filter(
+            entity =>
+              entity &&
+              typeof entity === 'object' &&
+              entity.id &&
+              entity.id.uuid &&
+              entity.type === 'image'
+          )
+        );
+      });
+
+      // Combine all entities (users + configured products + bestseller products + images)
+      const allEntities = [...validUsers, ...validConfigProducts, ...bestsellerProducts];
+      const allIncluded = [...validIncluded, ...validConfigProductImages, ...bestsellerImages];
 
       // Only dispatch if we have valid data
       if (allEntities.length > 0 || allIncluded.length > 0) {
@@ -299,7 +382,7 @@ export const fetchBrands = (params = {}) => (dispatch, getState, sdk) => {
         dispatch(addMarketplaceEntities({ data: entityPayload }));
       }
 
-      // Store brand IDs and pagination
+      // Store brand IDs, bestseller products info, and pagination
       const successfulBrandIds = validUsers.map(user => user.id.uuid);
       dispatch(
         fetchBrandsSuccess(successfulBrandIds, {
@@ -309,6 +392,9 @@ export const fetchBrands = (params = {}) => (dispatch, getState, sdk) => {
           totalItems,
         })
       );
+
+      // Store bestseller products metadata for selector to use
+      dispatch(setBestsellerProducts(bestsellersByBrand));
 
       return { data: validUsers };
     })
@@ -354,6 +440,12 @@ export const fetchFeaturedBrands = () => (dispatch, getState, sdk) => {
       })
   );
 
+  // Fetch bestseller products for each featured brand in parallel
+  const bestsellerPromises = featuredIds.map(brandId =>
+    fetchBestsellerListingsForBrand(sdk, brandId)
+      .then(result => ({ brandId, ...result }))
+  );
+
   // Batch fetch ALL featured products for these brands in ONE query (performance optimization)
   const allProductIds = getFeaturedProductIds(featuredIds);
   const productsPromise =
@@ -379,10 +471,22 @@ export const fetchFeaturedBrands = () => (dispatch, getState, sdk) => {
           })
       : Promise.resolve({ data: [], included: [] });
 
-  // Wait for both brands and products to fetch in parallel
-  return Promise.all([Promise.all(brandPromises), productsPromise])
-    .then(([brandResponses, productsResponse]) => {
+  // Wait for brands, bestsellers, and configured products to fetch in parallel
+  return Promise.all([Promise.all(brandPromises), Promise.all(bestsellerPromises), productsPromise])
+    .then(([brandResponses, bestsellerResponses, configProductsResponse]) => {
       const validResponses = brandResponses.filter(r => r !== null);
+
+      // Build bestseller products map by brand ID
+      const bestsellersByBrand = {};
+      (bestsellerResponses || []).forEach(({ brandId, data = [], included = [] }) => {
+        if (data.length > 0) {
+          // Randomize and select up to 4 bestseller products
+          bestsellersByBrand[brandId] = {
+            data: pickRandom(data, 4),
+            included,
+          };
+        }
+      });
 
       // Filter out any invalid user objects
       const users = validResponses
@@ -443,12 +547,12 @@ export const fetchFeaturedBrands = () => (dispatch, getState, sdk) => {
 
       const validIncluded = included.filter(e => e !== undefined && e !== null);
 
-      // Process products response
-      const products = productsResponse.data || [];
-      const productImages = productsResponse.included || [];
+      // Process configured products response
+      const configProducts = configProductsResponse.data || [];
+      const configProductImages = configProductsResponse.included || [];
 
-      // Filter valid products
-      const validProducts = products.filter(
+      // Filter valid configured products
+      const validConfigProducts = configProducts.filter(
         listing =>
           listing &&
           typeof listing === 'object' &&
@@ -457,7 +561,7 @@ export const fetchFeaturedBrands = () => (dispatch, getState, sdk) => {
           listing.type === 'listing'
       );
 
-      const validProductImages = productImages.filter(
+      const validConfigProductImages = configProductImages.filter(
         entity =>
           entity &&
           typeof entity === 'object' &&
@@ -466,9 +570,35 @@ export const fetchFeaturedBrands = () => (dispatch, getState, sdk) => {
           entity.type === 'image'
       );
 
-      // Combine all entities (users + products + images)
-      const allEntities = [...validUsers, ...validProducts];
-      const allIncluded = [...validIncluded, ...validProductImages];
+      // Process bestseller products and include them
+      let bestsellerProducts = [];
+      let bestsellerImages = [];
+      Object.values(bestsellersByBrand).forEach(({ data = [], included = [] }) => {
+        bestsellerProducts = bestsellerProducts.concat(
+          data.filter(
+            listing =>
+              listing &&
+              typeof listing === 'object' &&
+              listing.id &&
+              listing.id.uuid &&
+              listing.type === 'listing'
+          )
+        );
+        bestsellerImages = bestsellerImages.concat(
+          included.filter(
+            entity =>
+              entity &&
+              typeof entity === 'object' &&
+              entity.id &&
+              entity.id.uuid &&
+              entity.type === 'image'
+          )
+        );
+      });
+
+      // Combine all entities (users + configured products + bestseller products + images)
+      const allEntities = [...validUsers, ...validConfigProducts, ...bestsellerProducts];
+      const allIncluded = [...validIncluded, ...validConfigProductImages, ...bestsellerImages];
 
       // Only dispatch if we have valid data
       if (allEntities.length > 0 || allIncluded.length > 0) {
@@ -484,6 +614,9 @@ export const fetchFeaturedBrands = () => (dispatch, getState, sdk) => {
 
       const successfulBrandIds = validUsers.map(user => user.id.uuid);
       dispatch(fetchFeaturedBrandsSuccess(successfulBrandIds));
+
+      // Store bestseller products metadata for selector to use
+      dispatch(setBestsellerProducts(bestsellersByBrand));
 
       return { data: validUsers };
     })
@@ -525,7 +658,7 @@ export const getBrands = state => {
  * Returns array of { brand, products } objects
  */
 export const getBrandsWithProducts = state => {
-  const { brandIds } = state.BrandsPage;
+  const { brandIds, bestsellerProductsByBrand } = state.BrandsPage;
   const { entities } = state.marketplaceData;
 
   // Get denormalized brands
@@ -537,14 +670,29 @@ export const getBrandsWithProducts = state => {
 
   // Attach products to each brand
   return brands.map(brand => {
-    const brandConfig = getBrandConfiguration(brand.id.uuid);
-    const productIds = brandConfig?.featuredProductIds || [];
+    const brandId = brand.id.uuid;
+    const brandConfig = getBrandConfiguration(brandId);
 
-    const products = denormalisedEntities(
-      entities,
-      productIds.map(id => ({ id: { uuid: id }, type: 'listing' })),
-      false
-    );
+    // Try to use bestseller products first; fallback to configured products
+    let products = [];
+    const bestsellerInfo = bestsellerProductsByBrand?.[brandId];
+
+    if (bestsellerInfo?.data && bestsellerInfo.data.length > 0) {
+      // Denormalize bestseller product IDs to attach images from marketplace entities
+      products = denormalisedEntities(
+        entities,
+        bestsellerInfo.data.map(listing => ({ id: { uuid: listing.id.uuid }, type: 'listing' })),
+        false
+      );
+    } else {
+      // Fallback to configured featured product IDs
+      const configuredProductIds = brandConfig?.featuredProductIds || [];
+      products = denormalisedEntities(
+        entities,
+        configuredProductIds.map(id => ({ id: { uuid: id }, type: 'listing' })),
+        false
+      );
+    }
 
     return {
       brand,
@@ -570,7 +718,7 @@ export const getFeaturedBrands = state => {
  * Returns array of { brand, products } objects
  */
 export const getFeaturedBrandsWithProducts = state => {
-  const { featuredBrandIds } = state.BrandsPage;
+  const { featuredBrandIds, bestsellerProductsByBrand } = state.BrandsPage;
   const { entities } = state.marketplaceData;
 
   // Get denormalized brands
@@ -582,14 +730,29 @@ export const getFeaturedBrandsWithProducts = state => {
 
   // Attach products to each brand
   return brands.map(brand => {
-    const brandConfig = getBrandConfiguration(brand.id.uuid);
-    const productIds = brandConfig?.featuredProductIds || [];
+    const brandId = brand.id.uuid;
+    const brandConfig = getBrandConfiguration(brandId);
 
-    const products = denormalisedEntities(
-      entities,
-      productIds.map(id => ({ id: { uuid: id }, type: 'listing' })),
-      false
-    );
+    // Try to use bestseller products first; fallback to configured products
+    let products = [];
+    const bestsellerInfo = bestsellerProductsByBrand?.[brandId];
+
+    if (bestsellerInfo?.data && bestsellerInfo.data.length > 0) {
+      // Denormalize bestseller product IDs to attach images from marketplace entities
+      products = denormalisedEntities(
+        entities,
+        bestsellerInfo.data.map(listing => ({ id: { uuid: listing.id.uuid }, type: 'listing' })),
+        false
+      );
+    } else {
+      // Fallback to configured featured product IDs
+      const configuredProductIds = brandConfig?.featuredProductIds || [];
+      products = denormalisedEntities(
+        entities,
+        configuredProductIds.map(id => ({ id: { uuid: id }, type: 'listing' })),
+        false
+      );
+    }
 
     return {
       brand,

--- a/src/containers/BrandsPage/BrandsPage.duck.test.js
+++ b/src/containers/BrandsPage/BrandsPage.duck.test.js
@@ -1,0 +1,522 @@
+import {
+  FETCH_BRANDS_REQUEST,
+  FETCH_BRANDS_SUCCESS,
+  FETCH_BRANDS_ERROR,
+  FETCH_FEATURED_BRANDS_REQUEST,
+  FETCH_FEATURED_BRANDS_SUCCESS,
+  FETCH_FEATURED_BRANDS_ERROR,
+  SET_BESTSELLER_PRODUCTS,
+  fetchBrandsRequest,
+  fetchBrandsSuccess,
+  fetchBrandsError,
+  fetchFeaturedBrandsRequest,
+  fetchFeaturedBrandsSuccess,
+  fetchFeaturedBrandsError,
+  setBestsellerProducts,
+  fetchBrands,
+  fetchFeaturedBrands,
+  getBrandsWithProducts,
+  getFeaturedBrandsWithProducts,
+} from './BrandsPage.duck';
+import brandsPageReducer from './BrandsPage.duck';
+
+describe('BrandsPage Duck', () => {
+  describe('Action Creators', () => {
+    describe('fetchBrandsRequest', () => {
+      it('should return action with correct type', () => {
+        const action = fetchBrandsRequest();
+        expect(action.type).toBe(FETCH_BRANDS_REQUEST);
+      });
+    });
+
+    describe('fetchBrandsSuccess', () => {
+      it('should return action with brandIds and pagination', () => {
+        const brandIds = ['id1', 'id2'];
+        const pagination = { page: 1, perPage: 24, totalPages: 5, totalItems: 100 };
+        const action = fetchBrandsSuccess(brandIds, pagination);
+
+        expect(action.type).toBe(FETCH_BRANDS_SUCCESS);
+        expect(action.payload.brandIds).toEqual(brandIds);
+        expect(action.payload.pagination).toEqual(pagination);
+      });
+    });
+
+    describe('fetchBrandsError', () => {
+      it('should return action with error payload', () => {
+        const error = new Error('Failed to fetch');
+        const action = fetchBrandsError(error);
+
+        expect(action.type).toBe(FETCH_BRANDS_ERROR);
+        expect(action.payload).toEqual(error);
+        expect(action.error).toBe(true);
+      });
+    });
+
+    describe('setBestsellerProducts', () => {
+      it('should return action with bestseller products map', () => {
+        const bestsellersByBrand = {
+          'brand-id-1': {
+            data: [{ id: { uuid: 'listing-1' }, type: 'listing' }],
+            included: [],
+          },
+        };
+        const action = setBestsellerProducts(bestsellersByBrand);
+
+        expect(action.type).toBe(SET_BESTSELLER_PRODUCTS);
+        expect(action.payload).toEqual(bestsellersByBrand);
+      });
+    });
+
+    describe('fetchFeaturedBrandsRequest', () => {
+      it('should return action with correct type', () => {
+        const action = fetchFeaturedBrandsRequest();
+        expect(action.type).toBe(FETCH_FEATURED_BRANDS_REQUEST);
+      });
+    });
+
+    describe('fetchFeaturedBrandsSuccess', () => {
+      it('should return action with featured brand IDs', () => {
+        const brandIds = ['featured-1', 'featured-2'];
+        const action = fetchFeaturedBrandsSuccess(brandIds);
+
+        expect(action.type).toBe(FETCH_FEATURED_BRANDS_SUCCESS);
+        expect(action.payload.brandIds).toEqual(brandIds);
+      });
+    });
+
+    describe('fetchFeaturedBrandsError', () => {
+      it('should return action with error', () => {
+        const error = new Error('Featured fetch failed');
+        const action = fetchFeaturedBrandsError(error);
+
+        expect(action.type).toBe(FETCH_FEATURED_BRANDS_ERROR);
+        expect(action.payload).toEqual(error);
+        expect(action.error).toBe(true);
+      });
+    });
+  });
+
+  describe('Reducer', () => {
+    const initialState = {
+      brandIds: [],
+      featuredBrandIds: [],
+      pagination: null,
+      fetchBrandsInProgress: false,
+      fetchBrandsError: null,
+      fetchFeaturedBrandsInProgress: false,
+      fetchFeaturedBrandsError: null,
+      bestsellerProductsByBrand: {},
+    };
+
+    it('should return initial state', () => {
+      const state = brandsPageReducer(undefined, {});
+      expect(state).toEqual(initialState);
+    });
+
+    describe('FETCH_BRANDS_REQUEST', () => {
+      it('should set fetchBrandsInProgress to true and clear error', () => {
+        const state = brandsPageReducer(initialState, {
+          type: FETCH_BRANDS_REQUEST,
+        });
+
+        expect(state.fetchBrandsInProgress).toBe(true);
+        expect(state.fetchBrandsError).toBe(null);
+      });
+    });
+
+    describe('FETCH_BRANDS_SUCCESS', () => {
+      it('should set brand IDs and pagination, clear loading state', () => {
+        const brandIds = ['brand-1', 'brand-2'];
+        const pagination = { page: 1, perPage: 24, totalPages: 5, totalItems: 100 };
+
+        const state = brandsPageReducer(
+          { ...initialState, fetchBrandsInProgress: true },
+          {
+            type: FETCH_BRANDS_SUCCESS,
+            payload: { brandIds, pagination },
+          }
+        );
+
+        expect(state.brandIds).toEqual(brandIds);
+        expect(state.pagination).toEqual(pagination);
+        expect(state.fetchBrandsInProgress).toBe(false);
+      });
+
+      it('should append brand IDs on pagination', () => {
+        const existingState = {
+          ...initialState,
+          brandIds: ['existing-1', 'existing-2'],
+        };
+
+        const newBrandIds = ['brand-3', 'brand-4'];
+        const pagination = { page: 2, perPage: 24 };
+
+        const state = brandsPageReducer(existingState, {
+          type: FETCH_BRANDS_SUCCESS,
+          payload: { brandIds: newBrandIds, pagination },
+        });
+
+        expect(state.brandIds).toEqual(['existing-1', 'existing-2', 'brand-3', 'brand-4']);
+      });
+
+      it('should replace brand IDs on first page', () => {
+        const existingState = {
+          ...initialState,
+          brandIds: ['old-1', 'old-2'],
+        };
+
+        const newBrandIds = ['new-1', 'new-2'];
+        const pagination = { page: 1, perPage: 24 };
+
+        const state = brandsPageReducer(existingState, {
+          type: FETCH_BRANDS_SUCCESS,
+          payload: { brandIds: newBrandIds, pagination },
+        });
+
+        expect(state.brandIds).toEqual(newBrandIds);
+      });
+    });
+
+    describe('FETCH_BRANDS_ERROR', () => {
+      it('should set error and clear loading state', () => {
+        const error = new Error('Fetch failed');
+
+        const state = brandsPageReducer(
+          { ...initialState, fetchBrandsInProgress: true },
+          {
+            type: FETCH_BRANDS_ERROR,
+            payload: error,
+          }
+        );
+
+        expect(state.fetchBrandsError).toEqual(error);
+        expect(state.fetchBrandsInProgress).toBe(false);
+      });
+    });
+
+    describe('SET_BESTSELLER_PRODUCTS', () => {
+      it('should set bestseller products by brand', () => {
+        const bestsellersByBrand = {
+          'brand-1': {
+            data: [{ id: { uuid: 'listing-1' } }],
+            included: [{ id: { uuid: 'image-1' } }],
+          },
+        };
+
+        const state = brandsPageReducer(initialState, {
+          type: SET_BESTSELLER_PRODUCTS,
+          payload: bestsellersByBrand,
+        });
+
+        expect(state.bestsellerProductsByBrand).toEqual(bestsellersByBrand);
+      });
+    });
+
+    describe('FETCH_FEATURED_BRANDS_REQUEST', () => {
+      it('should set fetchFeaturedBrandsInProgress to true', () => {
+        const state = brandsPageReducer(initialState, {
+          type: FETCH_FEATURED_BRANDS_REQUEST,
+        });
+
+        expect(state.fetchFeaturedBrandsInProgress).toBe(true);
+        expect(state.fetchFeaturedBrandsError).toBe(null);
+      });
+    });
+
+    describe('FETCH_FEATURED_BRANDS_SUCCESS', () => {
+      it('should set featured brand IDs and clear loading', () => {
+        const brandIds = ['featured-1', 'featured-2'];
+
+        const state = brandsPageReducer(
+          { ...initialState, fetchFeaturedBrandsInProgress: true },
+          {
+            type: FETCH_FEATURED_BRANDS_SUCCESS,
+            payload: { brandIds },
+          }
+        );
+
+        expect(state.featuredBrandIds).toEqual(brandIds);
+        expect(state.fetchFeaturedBrandsInProgress).toBe(false);
+      });
+    });
+
+    describe('FETCH_FEATURED_BRANDS_ERROR', () => {
+      it('should set error and clear loading state', () => {
+        const error = new Error('Featured fetch failed');
+
+        const state = brandsPageReducer(
+          { ...initialState, fetchFeaturedBrandsInProgress: true },
+          {
+            type: FETCH_FEATURED_BRANDS_ERROR,
+            payload: error,
+          }
+        );
+
+        expect(state.fetchFeaturedBrandsError).toEqual(error);
+        expect(state.fetchFeaturedBrandsInProgress).toBe(false);
+      });
+    });
+  });
+
+  describe('Selectors', () => {
+    const mockEntities = {
+      user: {
+        'brand-1': {
+          id: { uuid: 'brand-1' },
+          type: 'user',
+          attributes: { profile: { displayName: 'Brand 1' } },
+        },
+      },
+      listing: {
+        'listing-config-1': {
+          id: { uuid: 'listing-config-1' },
+          type: 'listing',
+          attributes: { title: 'Config Product 1' },
+          relationships: {
+            images: {
+              data: [{ id: { uuid: 'image-1' }, type: 'image' }],
+            },
+          },
+        },
+        'listing-bestseller-1': {
+          id: { uuid: 'listing-bestseller-1' },
+          type: 'listing',
+          attributes: { title: 'Bestseller Product 1' },
+          relationships: {
+            images: {
+              data: [{ id: { uuid: 'image-bs-1' }, type: 'image' }],
+            },
+          },
+        },
+      },
+      image: {
+        'image-1': {
+          id: { uuid: 'image-1' },
+          type: 'image',
+          attributes: {
+            variants: {
+              'square-small': { url: 'http://example.com/image-1.jpg' },
+            },
+          },
+        },
+        'image-bs-1': {
+          id: { uuid: 'image-bs-1' },
+          type: 'image',
+          attributes: {
+            variants: {
+              'square-small': { url: 'http://example.com/image-bs-1.jpg' },
+            },
+          },
+        },
+      },
+    };
+
+    describe('getBrandsWithProducts', () => {
+      it('should use bestseller products when available', () => {
+        const state = {
+          BrandsPage: {
+            brandIds: ['brand-1'],
+            bestsellerProductsByBrand: {
+              'brand-1': {
+                data: [
+                  {
+                    id: { uuid: 'listing-bestseller-1' },
+                    type: 'listing',
+                  },
+                ],
+                included: [],
+              },
+            },
+          },
+          marketplaceData: {
+            entities: mockEntities,
+          },
+        };
+
+        const result = getBrandsWithProducts(state);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].brand.id.uuid).toBe('brand-1');
+        expect(result[0].products).toHaveLength(1);
+        expect(result[0].products[0].id.uuid).toBe('listing-bestseller-1');
+      });
+
+      it('should fallback to configured products when no bestsellers', () => {
+        const state = {
+          BrandsPage: {
+            brandIds: ['brand-1'],
+            bestsellerProductsByBrand: {},
+          },
+          marketplaceData: {
+            entities: mockEntities,
+          },
+        };
+
+        // Mock getBrandConfiguration to return configured product IDs
+        jest.doMock('../../config/configBrands', () => ({
+          getBrandConfiguration: () => ({
+            featuredProductIds: ['listing-config-1'],
+          }),
+          getBrandCategory: () => 'baby_and_kids',
+        }));
+
+        const result = getBrandsWithProducts(state);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].products).toHaveLength(1);
+        expect(result[0].products[0].id.uuid).toBe('listing-config-1');
+      });
+
+      it('should return empty products when no bestsellers or config', () => {
+        const state = {
+          BrandsPage: {
+            brandIds: ['brand-1'],
+            bestsellerProductsByBrand: {},
+          },
+          marketplaceData: {
+            entities: mockEntities,
+          },
+        };
+
+        jest.doMock('../../config/configBrands', () => ({
+          getBrandConfiguration: () => ({
+            featuredProductIds: [],
+          }),
+          getBrandCategory: () => 'baby_and_kids',
+        }));
+
+        const result = getBrandsWithProducts(state);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].products).toHaveLength(0);
+      });
+    });
+
+    describe('getFeaturedBrandsWithProducts', () => {
+      it('should use bestseller products when available for featured brands', () => {
+        const state = {
+          BrandsPage: {
+            featuredBrandIds: ['brand-1'],
+            bestsellerProductsByBrand: {
+              'brand-1': {
+                data: [
+                  {
+                    id: { uuid: 'listing-bestseller-1' },
+                    type: 'listing',
+                  },
+                ],
+                included: [],
+              },
+            },
+          },
+          marketplaceData: {
+            entities: mockEntities,
+          },
+        };
+
+        const result = getFeaturedBrandsWithProducts(state);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].products).toHaveLength(1);
+        expect(result[0].products[0].id.uuid).toBe('listing-bestseller-1');
+      });
+    });
+  });
+
+  describe('Thunks', () => {
+    const mockSdk = {
+      users: {
+        show: jest.fn(),
+      },
+      listings: {
+        query: jest.fn(),
+      },
+    };
+
+    const mockDispatch = jest.fn();
+    const mockGetState = jest.fn();
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    describe('fetchBrands', () => {
+      it('should dispatch request, then success with brands', async () => {
+        const brandId = 'test-brand-id';
+        const mockBrandResponse = {
+          data: {
+            data: {
+              id: { uuid: brandId },
+              type: 'user',
+              attributes: { profile: { displayName: 'Test Brand' } },
+            },
+          },
+        };
+
+        const mockProductsResponse = {
+          data: {
+            data: [],
+            included: [],
+          },
+        };
+
+        mockSdk.users.show.mockResolvedValue(mockBrandResponse);
+        mockSdk.listings.query.mockResolvedValue(mockProductsResponse);
+
+        jest.doMock('../../config/configBrands', () => ({
+          getPaginatedBrandIds: () => ({
+            brandIds: [brandId],
+            totalPages: 1,
+            totalItems: 1,
+          }),
+          getFeaturedProductIds: () => [],
+          getBrandConfiguration: () => ({ featuredProductIds: [] }),
+        }));
+
+        await fetchBrands({ page: 1, perPage: 24 })(mockDispatch, mockGetState, mockSdk);
+
+        // Verify dispatch was called with success
+        const successCalls = mockDispatch.mock.calls.filter(
+          call => call[0]?.type === FETCH_BRANDS_SUCCESS
+        );
+        expect(successCalls.length).toBeGreaterThan(0);
+      });
+
+      it('should handle bestseller fetch errors gracefully', async () => {
+        const brandId = 'test-brand-id';
+        const mockBrandResponse = {
+          data: {
+            data: {
+              id: { uuid: brandId },
+              type: 'user',
+              attributes: { profile: { displayName: 'Test Brand' } },
+            },
+          },
+        };
+
+        mockSdk.users.show.mockResolvedValue(mockBrandResponse);
+        mockSdk.listings.query
+          .mockRejectedValueOnce(new Error('Bestseller fetch failed'))
+          .mockResolvedValueOnce({ data: { data: [], included: [] } });
+
+        jest.doMock('../../config/configBrands', () => ({
+          getPaginatedBrandIds: () => ({
+            brandIds: [brandId],
+            totalPages: 1,
+            totalItems: 1,
+          }),
+          getFeaturedProductIds: () => [],
+          getBrandConfiguration: () => ({ featuredProductIds: [] }),
+        }));
+
+        await fetchBrands({ page: 1, perPage: 24 })(mockDispatch, mockGetState, mockSdk);
+
+        // Should still succeed despite bestseller error
+        const successCalls = mockDispatch.mock.calls.filter(
+          call => call[0]?.type === FETCH_BRANDS_SUCCESS
+        );
+        expect(successCalls.length).toBeGreaterThan(0);
+      });
+    });
+  });
+});

--- a/src/containers/ListingPage/ImageCarousel/ImageCarousel.js
+++ b/src/containers/ListingPage/ImageCarousel/ImageCarousel.js
@@ -20,6 +20,7 @@ const IMAGE_GALLERY_OPTIONS = {
   showThumbnails: false,
   showFullscreenButton: false,
   slideDuration: 350,
+  swipeWithoutMouseEvents: true,
 };
 
 /**

--- a/src/containers/MelaHomePage/sections/CategoryShowcase/CategoryShowcase.js
+++ b/src/containers/MelaHomePage/sections/CategoryShowcase/CategoryShowcase.js
@@ -5,6 +5,7 @@ import { NamedLink, ListingCard, ProductCarousel } from '../../../../components'
 import { useConfiguration } from '../../../../context/configurationContext';
 import { createInstance } from '../../../../util/sdkLoader';
 import { denormalisedEntities, updatedEntities, pickBrandDiverse } from '../../../../util/data';
+import { fetchBestsellerCarousel } from '../../../../util/bestsellerCarousel';
 import appSettings from '../../../../config/settings';
 import * as apiUtils from '../../../../util/api';
 
@@ -143,6 +144,7 @@ export const OccasionStrip = ({ config, additionalQueryParams = {} }) => {
   const orderedOccasions = inSeason ? OCCASIONS : [...OCCASIONS].reverse();
 
   const additionalParamsKey = JSON.stringify(additionalQueryParams);
+  const DISPLAY_COUNT = 6;
 
   useEffect(() => {
     const listingFields = config?.listing?.listingFields;
@@ -154,14 +156,19 @@ export const OccasionStrip = ({ config, additionalQueryParams = {} }) => {
         const results = await Promise.all(
           OCCASIONS.map(async ({ option }) => {
             try {
-              const response = await sdk.listings.query({
-                pub_occasion: option,
-                perPage: 50,
-                include: ['images', 'currentStock'],
-                ...additionalQueryParams,
-              });
-              const listingIds = pickBrandDiverse(response.data.data, 6);
-              return { option, listingIds, responseData: response.data };
+              const { pool, allIncluded } = await fetchBestsellerCarousel(
+                sdk,
+                {
+                  pub_occasion: option,
+                  include: ['images', 'currentStock'],
+                  ...additionalQueryParams,
+                },
+                DISPLAY_COUNT
+              );
+
+              // Pick diverse brands from the pool
+              const listingIds = pickBrandDiverse(pool, DISPLAY_COUNT);
+              return { option, listingIds, responseData: { data: pool, included: allIncluded } };
             } catch {
               return { option, listingIds: [], responseData: null };
             }
@@ -303,6 +310,8 @@ const AgeNavigation = ({ config }) => {
   const [ageProducts, setAgeProducts] = useState({});
   const [isLoading, setIsLoading] = useState(true);
 
+  const DISPLAY_COUNT = 8;
+
   useEffect(() => {
     const listingFields = config?.listing?.listingFields;
     const sanitizeConfig = { listingFields };
@@ -312,13 +321,18 @@ const AgeNavigation = ({ config }) => {
         const results = await Promise.all(
           TOP_AGE_GROUPS.map(async ({ option }) => {
             try {
-              const response = await sdk.listings.query({
-                pub_age_group: option,
-                perPage: 100,
-                include: ['images', 'currentStock'],
-              });
-              const listingIds = pickBrandDiverse(response.data.data, 8);
-              return { option, listingIds, responseData: response.data };
+              const { pool, allIncluded } = await fetchBestsellerCarousel(
+                sdk,
+                {
+                  pub_age_group: option,
+                  include: ['images', 'currentStock'],
+                },
+                DISPLAY_COUNT
+              );
+
+              // Pick diverse brands from the pool
+              const listingIds = pickBrandDiverse(pool, DISPLAY_COUNT);
+              return { option, listingIds, responseData: { data: pool, included: allIncluded } };
             } catch {
               return { option, listingIds: [], responseData: null };
             }
@@ -384,6 +398,8 @@ const makeCategoryCarousels = (categories) => {
     const [categoryProducts, setCategoryProducts] = useState({});
     const [isLoading, setIsLoading] = useState(true);
 
+    const DISPLAY_COUNT = 8;
+
     useEffect(() => {
       const listingFields = config?.listing?.listingFields;
       const sanitizeConfig = { listingFields };
@@ -393,13 +409,18 @@ const makeCategoryCarousels = (categories) => {
           const results = await Promise.all(
             categories.map(async ({ id }) => {
               try {
-                const response = await sdk.listings.query({
-                  pub_categoryLevel1: id,
-                  perPage: 100,
-                  include: ['images', 'currentStock'],
-                });
-                const listingIds = pickBrandDiverse(response.data.data, 8);
-                return { id, listingIds, responseData: response.data };
+                const { pool, allIncluded } = await fetchBestsellerCarousel(
+                  sdk,
+                  {
+                    pub_categoryLevel1: id,
+                    include: ['images', 'currentStock'],
+                  },
+                  DISPLAY_COUNT
+                );
+
+                // Pick diverse brands from the pool
+                const listingIds = pickBrandDiverse(pool, DISPLAY_COUNT);
+                return { id, listingIds, responseData: { data: pool, included: allIncluded } };
               } catch {
                 return { id, listingIds: [], responseData: null };
               }

--- a/src/containers/MelaHomePage/sections/CategoryShowcase/CategoryShowcase.module.css
+++ b/src/containers/MelaHomePage/sections/CategoryShowcase/CategoryShowcase.module.css
@@ -160,6 +160,7 @@
   padding: 1.25rem 1rem 1rem;
   display: flex;
   flex-direction: column;
+  overflow-x: hidden;
 
   @media (min-width: 640px) {
     margin: 0 -1.5rem;

--- a/src/ducks/categoryProducts.duck.js
+++ b/src/ducks/categoryProducts.duck.js
@@ -1,4 +1,6 @@
 import { storableError } from '../util/errors';
+import { pickRandom, attachImagesToListings } from '../util/listings';
+import { fetchBestsellerCarousel } from '../util/bestsellerCarousel';
 
 // ================ Action types ================ //
 
@@ -84,6 +86,8 @@ export const fetchCategoryProductsError = (categoryKey, error) => ({
 
 // ================ Thunks ================ //
 
+const DISPLAY_COUNT = 9; // Limit to 9 products for optimal UX and performance
+
 export const fetchCategoryProducts = (categoryLevel, categoryName, config, excludeListingId = null) => (dispatch, getState, sdk) => {
   const categoryKey = `${categoryLevel}:${categoryName}`;
 
@@ -101,53 +105,23 @@ export const fetchCategoryProducts = (categoryLevel, categoryName, config, exclu
     ],
     'fields.user': ['profile.displayName', 'profile.abbreviatedName'],
     'fields.image': ['variants.listing-card', 'variants.listing-card-2x'],
-    'imageVariant.listing-card': 'w:400;h:300;fit:crop', // Define listing-card variant
-    'imageVariant.listing-card-2x': 'w:800;h:600;fit:crop', // Define listing-card-2x variant
-    perPage: 9, // Limit to 9 products for optimal UX and performance
+    'imageVariant.listing-card': 'w:400;h:300;fit:crop',
+    'imageVariant.listing-card-2x': 'w:800;h:600;fit:crop',
     [`pub_${categoryLevel}`]: categoryName,
   };
 
-  return sdk.listings
-    .query(queryParams)
-    .then(response => {
-      const { data, included } = response.data;
-
-      // Helper function to attach images to listings from included data
-      const attachImagesToListings = (listings, includedData) => {
-        const imageMap = {};
-
-        // Create a map of image IDs to image objects
-        (includedData || []).forEach(item => {
-          if (item.type === 'image') {
-            imageMap[item.id.uuid] = item;
-          }
-        });
-
-        // Attach images to each listing
-        return listings.map(listing => {
-          const imageRelationships = listing.relationships?.images?.data || [];
-          const images = imageRelationships.map(rel => imageMap[rel.id.uuid]).filter(Boolean);
-
-          return {
-            ...listing,
-            images: images, // Top-level: required by ListingImage (listing.images[0])
-            attributes: {
-              ...listing.attributes,
-            }
-          };
-        });
-      };
-
-      // Process listings to include image data
-      let listingsWithImages = attachImagesToListings(data, included);
+  return fetchBestsellerCarousel(sdk, queryParams, DISPLAY_COUNT)
+    .then(({ pool, allIncluded }) => {
+      // Attach images and randomize
+      const listingsWithImages = attachImagesToListings(pool, allIncluded);
+      let finalListings = pickRandom(listingsWithImages, DISPLAY_COUNT);
 
       // Filter out the current listing if excludeListingId is provided
       if (excludeListingId) {
-        listingsWithImages = listingsWithImages.filter(listing => listing.id.uuid !== excludeListingId);
+        finalListings = finalListings.filter(listing => listing.id.uuid !== excludeListingId);
       }
 
-      dispatch(fetchCategoryProductsSuccess(categoryKey, listingsWithImages));
-      return response;
+      dispatch(fetchCategoryProductsSuccess(categoryKey, finalListings));
     })
     .catch(e => {
       const error = storableError(e);

--- a/src/util/bestsellerCarousel.js
+++ b/src/util/bestsellerCarousel.js
@@ -1,0 +1,58 @@
+/**
+ * Utility for fetching listings with bestseller-first strategy.
+ * Used by category, occasion, and age-group carousels.
+ */
+
+/**
+ * Fetch listings with bestseller-first fallback strategy.
+ * First tries to fetch bestseller listings; if pool is small, appends non-bestseller results.
+ *
+ * @param {Object} sdk - Sharetribe SDK instance
+ * @param {Object} queryParams - Base query parameters (category, occasion, age_group filter, etc.)
+ * @param {number} displayCount - Target number of listings to display
+ * @returns {Promise<{pool: Array, allIncluded: Array}>} Combined pool and all included entities
+ */
+export const fetchBestsellerCarousel = async (sdk, queryParams, displayCount) => {
+  try {
+    // Step 1: Fetch bestseller listings first
+    const bestsellerResponse = await sdk.listings.query({
+      ...queryParams,
+      pub_isBestseller: true,
+      perPage: Math.max(displayCount * 2, 20), // Fetch ahead for deduplication buffer
+    });
+
+    let pool = bestsellerResponse.data.data || [];
+    let allIncluded = bestsellerResponse.data.included || [];
+
+    // Step 2: If bestseller pool is small, fetch all listings to fill the gap
+    if (pool.length < displayCount) {
+      try {
+        const allResponse = await sdk.listings.query({
+          ...queryParams,
+          perPage: 50,
+        });
+
+        const allListings = allResponse.data.data || [];
+        const allResponseIncluded = allResponse.data.included || [];
+
+        // Deduplicate: remove listings already in bestseller set
+        const bestsellerIds = new Set(pool.map(l => l.id.uuid));
+        const additionalListings = allListings.filter(l => !bestsellerIds.has(l.id.uuid));
+
+        // Combine bestsellers + additional non-bestsellers
+        pool = [...pool, ...additionalListings];
+
+        // Merge included data from both responses for complete entity resolution
+        allIncluded = [...allIncluded, ...allResponseIncluded];
+      } catch (error) {
+        // Fallback fetch failed, proceed with bestsellers only
+        console.warn('Bestseller carousel fallback fetch failed:', error);
+      }
+    }
+
+    return { pool, allIncluded };
+  } catch (error) {
+    console.error('Bestseller carousel fetch failed:', error);
+    return { pool: [], allIncluded: [] };
+  }
+};

--- a/src/util/listings.js
+++ b/src/util/listings.js
@@ -1,0 +1,55 @@
+/**
+ * Shared utilities for listing operations.
+ */
+
+/**
+ * Fisher-Yates shuffle algorithm for randomizing arrays.
+ * Properly randomizes an array (unlike sort-based approaches).
+ *
+ * @param {Array} arr - Array to randomize
+ * @param {number} count - Number of items to return (defaults to array length)
+ * @returns {Array} Randomized subset of the input array
+ */
+export const pickRandom = (arr, count) => {
+  if (arr.length <= count) return arr;
+  const shuffled = [...arr];
+  // Fisher-Yates shuffle algorithm
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+  return shuffled.slice(0, count);
+};
+
+/**
+ * Attach image objects to listings from normalized included data.
+ * Required because ListingImage component expects listing.images array.
+ *
+ * @param {Array} listings - Listing objects with image relationships
+ * @param {Array} includedData - Normalized image entities from API response
+ * @returns {Array} Listings with images array attached
+ */
+export const attachImagesToListings = (listings, includedData) => {
+  const imageMap = {};
+
+  // Create a map of image IDs to image objects
+  (includedData || []).forEach(item => {
+    if (item.type === 'image') {
+      imageMap[item.id.uuid] = item;
+    }
+  });
+
+  // Attach images to each listing
+  return listings.map(listing => {
+    const imageRelationships = listing.relationships?.images?.data || [];
+    const images = imageRelationships.map(rel => imageMap[rel.id.uuid]).filter(Boolean);
+
+    return {
+      ...listing,
+      images: images, // Top-level: required by ListingImage (listing.images[0])
+      attributes: {
+        ...listing.attributes,
+      },
+    };
+  });
+};


### PR DESCRIPTION
  - Shared listing utilities — extracted util/listings.js and util/bestsellerCarousel.js to eliminate duplicated bestseller-fetching logic across ducks;
  BrandsPage.duck and CategoryShowcase both now use fetchBestsellerCarousel
  - CategoryShowcase fix — occasion carousel was overflowing its panel bounds; contained with a CSS fix
  - ImageCarousel — enabled touch swipe without requiring mouse events (mobile UX improvement)
  - RedirectTrustSheet — added a 1.5s activation delay on the Continue button to reduce accidental taps
  - ListingCard — moved variant pill below the title for better visual hierarchy
  - Tests — added comprehensive test coverage for BrandsPage.duck bestseller carousel logic and RedirectTrustSheet button delay behavior