### PR TITLE
feat(analytics): add session_id to brand_clickout event

### DIFF
--- a/src/util/analytics/brandClickout.js
+++ b/src/util/analytics/brandClickout.js
@@ -14,6 +14,7 @@
  */
 
 import { getEntrySource } from './entrySource';
+import { getOrCreateSessionId } from '../sentimentCapture';
 
 /**
  * @param {object} params
@@ -36,6 +37,12 @@ export const pushBrandClickout = (params = {}) => {
     product_id: productId || null,
     entry_source: getEntrySource(),
     destination: destination || null,
+    // GA4 blocks registering its auto-collected `ga_session_id` as a custom
+    // dimension (reserved parameter name) — this reuses the app's own session
+    // ID (already used for sentiment capture) under a non-reserved key so the
+    // multi-brand-clickout/entry-vs-exit reports can group by session in GA4.
+    // See crossshop-tracking-prd.md §13.0.
+    session_id: getOrCreateSessionId(),
   });
 };
 

--- a/src/util/analytics/brandClickout.test.js
+++ b/src/util/analytics/brandClickout.test.js
@@ -17,17 +17,28 @@ describe('pushBrandClickout(params)', () => {
       destination: 'https://superbottoms.com/products/foo',
     });
 
-    expect(window.dataLayer).toEqual([
-      {
-        event: 'brand_clickout',
-        brand_name: 'SuperBottoms',
-        brand_id: 'author-uuid-123',
-        category: 'Baby-Kids',
-        product_id: 'listing-uuid-456',
-        entry_source: 'pinterest',
-        destination: 'https://superbottoms.com/products/foo',
-      },
-    ]);
+    expect(window.dataLayer).toHaveLength(1);
+    expect(window.dataLayer[0]).toMatchObject({
+      event: 'brand_clickout',
+      brand_name: 'SuperBottoms',
+      brand_id: 'author-uuid-123',
+      category: 'Baby-Kids',
+      product_id: 'listing-uuid-456',
+      entry_source: 'pinterest',
+      destination: 'https://superbottoms.com/products/foo',
+    });
+    // session_id is generated (not caller-supplied) — assert it's present and non-empty
+    // rather than exact-matching an unpredictable UUID. See PRD §13.0 for why this
+    // field exists (GA4 blocks registering its own ga_session_id as a custom dimension).
+    expect(typeof window.dataLayer[0].session_id).toBe('string');
+    expect(window.dataLayer[0].session_id.length).toBeGreaterThan(0);
+  });
+
+  it('reuses the same session_id across multiple pushes in the same session', () => {
+    pushBrandClickout({ brandName: 'Nicobar' });
+    pushBrandClickout({ brandName: 'SuperBottoms' });
+
+    expect(window.dataLayer[0].session_id).toEqual(window.dataLayer[1].session_id);
   });
 
   it('fills missing params with null rather than omitting the key', () => {

--- a/src/util/sentimentCapture.js
+++ b/src/util/sentimentCapture.js
@@ -59,7 +59,7 @@ export const markSentimentShown = () => {
 /**
  * Returns a persistent anonymous session ID for this browser session.
  */
-const getOrCreateSessionId = () => {
+export const getOrCreateSessionId = () => {
   try {
     let id = sessionStorage.getItem(SESSION_ID_KEY);
     if (!id) {


### PR DESCRIPTION
GA4 blocks registering its auto-collected ga_session_id as a custom dimension (reserved parameter name), which is needed to compute the multi-brand-clickout-rate and entry-vs-exit dashboards session-scoped. Reuses the existing app-level session ID (already used for sentiment capture) as a 7th brand_clickout param instead. Exports getOrCreateSessionId() from sentimentCapture.js for reuse. See crossshop-tracking-prd.md §13.0. Not yet live-verified — deploy and confirm via Tag Assistant before updating the PRD/docs schema.