### PR TITLE
fix(analytics): rename brand_clickout session_id to mela_session_id

### DIFF
--- a/src/util/analytics/brandClickout.js
+++ b/src/util/analytics/brandClickout.js
@@ -37,12 +37,14 @@ export const pushBrandClickout = (params = {}) => {
     product_id: productId || null,
     entry_source: getEntrySource(),
     destination: destination || null,
-    // GA4 blocks registering its auto-collected `ga_session_id` as a custom
-    // dimension (reserved parameter name) — this reuses the app's own session
-    // ID (already used for sentiment capture) under a non-reserved key so the
-    // multi-brand-clickout/entry-vs-exit reports can group by session in GA4.
-    // See crossshop-tracking-prd.md §13.0.
-    session_id: getOrCreateSessionId(),
+    // GA4 silently drops both its auto-collected `ga_session_id` AND a plain
+    // `session_id` parameter (reserved names — the former blocks custom
+    // dimension registration outright with an error, the latter is dropped
+    // from incoming events with no error at all). `mela_session_id` reuses
+    // the app's own session ID (already used for sentiment capture) under an
+    // unambiguously non-reserved key so the multi-brand-clickout/entry-vs-exit
+    // reports can group by session in GA4. See crossshop-tracking-prd.md §13.0.
+    mela_session_id: getOrCreateSessionId(),
   });
 };
 

--- a/src/util/analytics/brandClickout.test.js
+++ b/src/util/analytics/brandClickout.test.js
@@ -27,18 +27,19 @@ describe('pushBrandClickout(params)', () => {
       entry_source: 'pinterest',
       destination: 'https://superbottoms.com/products/foo',
     });
-    // session_id is generated (not caller-supplied) — assert it's present and non-empty
-    // rather than exact-matching an unpredictable UUID. See PRD §13.0 for why this
-    // field exists (GA4 blocks registering its own ga_session_id as a custom dimension).
-    expect(typeof window.dataLayer[0].session_id).toBe('string');
-    expect(window.dataLayer[0].session_id.length).toBeGreaterThan(0);
+    // mela_session_id is generated (not caller-supplied) — assert it's present and
+    // non-empty rather than exact-matching an unpredictable UUID. See PRD §13.0 for
+    // why this field exists and why it's prefixed (GA4 silently drops both its own
+    // ga_session_id AND a plain session_id — both are reserved/protected names).
+    expect(typeof window.dataLayer[0].mela_session_id).toBe('string');
+    expect(window.dataLayer[0].mela_session_id.length).toBeGreaterThan(0);
   });
 
-  it('reuses the same session_id across multiple pushes in the same session', () => {
+  it('reuses the same mela_session_id across multiple pushes in the same session', () => {
     pushBrandClickout({ brandName: 'Nicobar' });
     pushBrandClickout({ brandName: 'SuperBottoms' });
 
-    expect(window.dataLayer[0].session_id).toEqual(window.dataLayer[1].session_id);
+    expect(window.dataLayer[0].mela_session_id).toEqual(window.dataLayer[1].mela_session_id);
   });
 
   it('fills missing params with null rather than omitting the key', () => {


### PR DESCRIPTION
GA4 silently drops plain `session_id` from incoming events with no error (unlike ga_session_id, which at least errors explicitly when registering it as a custom dimension) — both are reserved/protected names. Confirmed via DebugView: all six original params reached GA4 correctly, session_id never did, despite verified-correct GTM tag and variable config and a fresh dataLayer push confirming the code side was never the problem. Renamed to the mela_-prefixed convention already used elsewhere (mela_entry_source, mela_session_id in sessionStorage) to avoid the reserved namespace entirely. Not yet live-verified with the new name — GTM variable/tag need matching updates before testing.