### PR TITLE
feat(homepage): query-time brand diversity + SLA-bounded fetch for di…

### DIFF
--- a/src/containers/MelaHomePage/sections/CategoryShowcase/CategoryShowcase.js
+++ b/src/containers/MelaHomePage/sections/CategoryShowcase/CategoryShowcase.js
@@ -4,7 +4,8 @@ import { FormattedMessage } from '../../../../util/reactIntl';
 import { NamedLink, ListingCard, ProductCarousel } from '../../../../components';
 import { useConfiguration } from '../../../../context/configurationContext';
 import { denormalisedEntities, updatedEntities, pickBrandDiverse } from '../../../../util/data';
-import { fetchBestsellerCarousel } from '../../../../util/bestsellerCarousel';
+import { fetchListingsAcrossBrands } from '../../../../util/bestsellerCarousel';
+import { allBrandIds, getBrandSlugById } from '../../../../config/configBrands';
 import sdk from '../../../../util/homepageSdk';
 
 import css from './CategoryShowcase.module.css';
@@ -41,6 +42,23 @@ export const isDiwaliSeason = () => {
   const day = now.getDate();
   return month === 10 || (month === 11 && day <= 15);
 };
+
+// Max listings fetched per brand for the fetchListingsAcrossBrands query-time
+// diversity strategy (see util/bestsellerCarousel.js) — shared across all three
+// carousels below. With ~18 configured brands this yields plenty of buffer over
+// each carousel's DISPLAY_COUNT even after client-side filtering/misses.
+const PER_BRAND_COUNT = 2;
+
+// Brands to leave out of the homepage discovery carousels (OccasionStrip,
+// AgeNavigation, AllCategoryCarousels) specifically — their listings still show
+// up everywhere else (search, category pages, their own /brands/:slug storefront).
+// Keyed by slug rather than UUID so this stays readable/editable without looking
+// up IDs in configBrands.js. Exported so a test can assert against configBrands.js's
+// real slugs and catch a typo here silently no-opping the exclusion.
+export const EXCLUDED_DISCOVERY_BRAND_SLUGS = ['superbottoms', 'isharya'];
+const DISCOVERY_BRAND_IDS = allBrandIds.filter(
+  id => !EXCLUDED_DISCOVERY_BRAND_SLUGS.includes(getBrandSlugById(id))
+);
 
 const TOP_AGE_GROUPS = [
   { option: 'newborn',     label: 'Newborn' },
@@ -124,7 +142,12 @@ const generateStructuredData = (categories, categoryProducts) => {
 
 export const OccasionStrip = ({ config, additionalQueryParams = {} }) => {
   const [occasionProducts, setOccasionProducts] = useState({});
-  const [isLoading, setIsLoading] = useState(true);
+  // Loading is tracked per occasion (not one shared flag) so a slow occasion's
+  // fetch never delays a faster sibling's panel from rendering — see the
+  // per-occasion effect below.
+  const [loadingByOccasion, setLoadingByOccasion] = useState(() =>
+    OCCASIONS.reduce((acc, { option }) => ({ ...acc, [option]: true }), {})
+  );
 
   const inSeason = isDiwaliSeason();
   // Show Diwali first during season, Gifting first off-season
@@ -137,63 +160,58 @@ export const OccasionStrip = ({ config, additionalQueryParams = {} }) => {
     const listingFields = config?.listing?.listingFields;
     const sanitizeConfig = { listingFields };
 
-    const fetchOccasionProducts = async () => {
-      setIsLoading(true);
-      try {
-        const results = await Promise.all(
-          OCCASIONS.map(async ({ option }) => {
-            try {
-              const { pool, allIncluded } = await fetchBestsellerCarousel(
-                sdk,
-                {
-                  pub_occasion: option,
-                  include: ['images', 'currentStock'],
-                  ...additionalQueryParams,
-                },
-                DISPLAY_COUNT
-              );
+    setLoadingByOccasion(OCCASIONS.reduce((acc, { option }) => ({ ...acc, [option]: true }), {}));
 
-              // Client-side guard: only keep raw listings that actually carry this
-              // occasion value in publicData. Protects against the pub_occasion search
-              // index not being set up in Sharetribe Console (filter silently ignored →
-              // all listings returned). Must run BEFORE pickBrandDiverse — diversifying
-              // first and filtering after would diversify across the whole unfiltered
-              // pool, then collapse back down to whichever single brand happens to have
-              // the most occasion-tagged listings once the irrelevant picks are dropped.
-              const occasionTagged = pool.filter(listing => {
-                const occasions = listing.attributes?.publicData?.occasion;
-                // Handle both storage formats:
-                // - array ['gifting'] when ingested with schema-aware parsing
-                // - string 'gifting' when ingested before schema config was loaded
-                return Array.isArray(occasions)
-                  ? occasions.includes(option)
-                  : occasions === option;
-              });
-              if (process.env.NODE_ENV !== 'production') {
-                console.debug(
-                  `[OccasionStrip] ${option}: ${pool.length} from API → ${occasionTagged.length} with occasion tag`
-                );
-              }
+    // Fire each occasion's fetch independently (not inside a shared Promise.all)
+    // and update only that occasion's slice of state on completion, so whichever
+    // occasion responds first renders first instead of both waiting on the
+    // slower of the two. fetchListingsAcrossBrands additionally bounds each
+    // per-brand request within a single occasion's fetch (see PER_BRAND_TIMEOUT_MS
+    // in util/bestsellerCarousel.js).
+    OCCASIONS.forEach(({ option }) => {
+      (async () => {
+        try {
+          // Query-time diversity: fetch a couple of listings from every configured
+          // brand rather than one marketplace-wide query, so one brand's inventory
+          // can't monopolize the pool before diversification even gets a chance.
+          const { pool, allIncluded } = await fetchListingsAcrossBrands(
+            sdk,
+            DISCOVERY_BRAND_IDS,
+            {
+              pub_occasion: option,
+              include: ['author', 'images', 'currentStock'],
+              ...additionalQueryParams,
+            },
+            PER_BRAND_COUNT
+          );
 
-              // Pick diverse brands from the occasion-tagged listings only
-              const listingIds = pickBrandDiverse(occasionTagged, DISPLAY_COUNT);
-              return { option, listingIds, responseData: { data: pool, included: allIncluded } };
-            } catch {
-              return { option, listingIds: [], responseData: null };
-            }
-          })
-        );
-
-        let allEntities = {};
-        results.forEach(r => {
-          if (r.responseData) {
-            allEntities = updatedEntities(allEntities, r.responseData, sanitizeConfig);
+          // Client-side guard: only keep raw listings that actually carry this
+          // occasion value in publicData. Protects against the pub_occasion search
+          // index not being set up in Sharetribe Console (filter silently ignored →
+          // all listings returned). Must run BEFORE pickBrandDiverse — diversifying
+          // first and filtering after would diversify across the whole unfiltered
+          // pool, then collapse back down to whichever single brand happens to have
+          // the most occasion-tagged listings once the irrelevant picks are dropped.
+          const occasionTagged = pool.filter(listing => {
+            const occasions = listing.attributes?.publicData?.occasion;
+            // Handle both storage formats:
+            // - array ['gifting'] when ingested with schema-aware parsing
+            // - string 'gifting' when ingested before schema config was loaded
+            return Array.isArray(occasions)
+              ? occasions.includes(option)
+              : occasions === option;
+          });
+          if (process.env.NODE_ENV !== 'production') {
+            console.debug(
+              `[OccasionStrip] ${option}: ${pool.length} from API → ${occasionTagged.length} with occasion tag`
+            );
           }
-        });
 
-        const productsMap = results.reduce((acc, { option, listingIds }) => {
+          // Pick diverse brands from the occasion-tagged listings only
+          const listingIds = pickBrandDiverse(occasionTagged, DISPLAY_COUNT);
+          const entities = updatedEntities({}, { data: pool, included: allIncluded }, sanitizeConfig);
           const refs = listingIds.map(id => ({ id, type: 'listing' }));
-          const all = denormalisedEntities(allEntities, refs, false);
+          const all = denormalisedEntities(entities, refs, false);
           // Defense-in-depth: listingIds were already picked from occasion-tagged,
           // brand-diverse listings above, so this should be a no-op in practice —
           // but re-check here too in case denormalisedEntities resolves a listing
@@ -204,30 +222,30 @@ export const OccasionStrip = ({ config, additionalQueryParams = {} }) => {
               ? occasions.includes(option)
               : occasions === option;
           });
-          acc[option] = filtered;
-          return acc;
-        }, {});
 
-        setOccasionProducts(productsMap);
-      } catch {
-        // Leave empty — panels with < 2 products won't render
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    fetchOccasionProducts();
+          setOccasionProducts(prev => ({ ...prev, [option]: filtered }));
+        } catch {
+          setOccasionProducts(prev => ({ ...prev, [option]: [] }));
+        } finally {
+          setLoadingByOccasion(prev => ({ ...prev, [option]: false }));
+        }
+      })();
+    });
   }, [additionalParamsKey]); // eslint-disable-line
 
-  // Determine which panels have enough products to show
+  const anyLoading = Object.values(loadingByOccasion).some(Boolean);
+
+  // Determine which panels have enough products to show — a still-loading
+  // occasion always stays visible (showing its own skeleton) regardless of
+  // whether a sibling occasion has already finished.
   const visibleOccasions = orderedOccasions.filter(
-    o => isLoading || (occasionProducts[o.option] || []).length >= 2
+    o => loadingByOccasion[o.option] || (occasionProducts[o.option] || []).length >= 2
   );
 
-  // Hide the entire strip if no occasion has enough products
-  if (!isLoading && visibleOccasions.length === 0) return null;
-
-  const occasionsToRender = isLoading ? orderedOccasions : visibleOccasions;
+  // Hide the entire strip only once every occasion has finished loading and
+  // none qualifies — never hide while a sibling might still turn out to have
+  // enough products.
+  if (!anyLoading && visibleOccasions.length === 0) return null;
 
   return (
     <div className={css.occasionStrip}>
@@ -236,11 +254,9 @@ export const OccasionStrip = ({ config, additionalQueryParams = {} }) => {
       </h3>
 
       <div className={css.occasionPanels}>
-        {occasionsToRender.map(occasion => {
+        {visibleOccasions.map(occasion => {
+          const stillLoading = loadingByOccasion[occasion.option];
           const products = occasionProducts[occasion.option] || [];
-          const hasEnough = products.length >= 2;
-
-          if (!isLoading && !hasEnough) return null;
 
           const ctaLabel = inSeason && occasion.ctaSeasonal ? occasion.ctaSeasonal : occasion.cta;
 
@@ -262,7 +278,7 @@ export const OccasionStrip = ({ config, additionalQueryParams = {} }) => {
               </div>
 
               {/* Product carousel — same HTML/CSS pattern as AgeNavigation */}
-              {isLoading ? (
+              {stillLoading ? (
                 <div className={css.productCarousel}>
                   {[1, 2, 3, 4].map(i => (
                     <div key={i} className={`${css.productSkeleton} ${css.carouselCard}`} />
@@ -312,7 +328,11 @@ export const OccasionStrip = ({ config, additionalQueryParams = {} }) => {
 // equal" positioning on the homepage) — CategoryPage.js renders it directly now.
 export const AgeNavigation = ({ config }) => {
   const [ageProducts, setAgeProducts] = useState({});
-  const [isLoading, setIsLoading] = useState(true);
+  // Loading tracked per age group so a slow group never delays a faster
+  // sibling's carousel from rendering (ProductCarousel takes isLoading per instance).
+  const [loadingByAgeGroup, setLoadingByAgeGroup] = useState(() =>
+    TOP_AGE_GROUPS.reduce((acc, { option }) => ({ ...acc, [option]: true }), {})
+  );
 
   const DISPLAY_COUNT = 8;
 
@@ -320,52 +340,36 @@ export const AgeNavigation = ({ config }) => {
     const listingFields = config?.listing?.listingFields;
     const sanitizeConfig = { listingFields };
 
-    const fetchAgeProducts = async () => {
-      try {
-        const results = await Promise.all(
-          TOP_AGE_GROUPS.map(async ({ option }) => {
-            try {
-              const { pool, allIncluded } = await fetchBestsellerCarousel(
-                sdk,
-                {
-                  pub_age_group: option,
-                  include: ['images', 'currentStock'],
-                },
-                DISPLAY_COUNT
-              );
+    // Fire each age group's fetch independently and update only its own slice
+    // of state on completion — see the matching pattern/rationale in OccasionStrip.
+    TOP_AGE_GROUPS.forEach(({ option }) => {
+      (async () => {
+        try {
+          const { pool, allIncluded } = await fetchListingsAcrossBrands(
+            sdk,
+            DISCOVERY_BRAND_IDS,
+            {
+              pub_age_group: option,
+              include: ['author', 'images', 'currentStock'],
+            },
+            PER_BRAND_COUNT
+          );
 
-              // Pick diverse brands from the pool
-              const listingIds = pickBrandDiverse(pool, DISPLAY_COUNT);
-              return { option, listingIds, responseData: { data: pool, included: allIncluded } };
-            } catch {
-              return { option, listingIds: [], responseData: null };
-            }
-          })
-        );
-
-        let allEntities = {};
-        results.forEach(r => {
-          if (r.responseData) {
-            allEntities = updatedEntities(allEntities, r.responseData, sanitizeConfig);
-          }
-        });
-
-        const productsMap = results.reduce((acc, { option, listingIds }) => {
+          // Pick diverse brands from the pool
+          const listingIds = pickBrandDiverse(pool, DISPLAY_COUNT);
+          const entities = updatedEntities({}, { data: pool, included: allIncluded }, sanitizeConfig);
           const refs = listingIds.map(id => ({ id, type: 'listing' }));
-          acc[option] = denormalisedEntities(allEntities, refs, false);
-          return acc;
-        }, {});
+          const listings = denormalisedEntities(entities, refs, false);
 
-        setAgeProducts(productsMap);
-      } catch {
-        // leave empty
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    fetchAgeProducts();
-  }, []);
+          setAgeProducts(prev => ({ ...prev, [option]: listings }));
+        } catch {
+          setAgeProducts(prev => ({ ...prev, [option]: [] }));
+        } finally {
+          setLoadingByAgeGroup(prev => ({ ...prev, [option]: false }));
+        }
+      })();
+    });
+  }, []); // eslint-disable-line
 
   return (
     <div className={css.ageNavigation}>
@@ -380,7 +384,7 @@ export const AgeNavigation = ({ config }) => {
             viewAllLinkName="SearchPage"
             viewAllLinkSearch={`?pub_categoryLevel1=Baby-Clothes-Accessories&pub_age_group=${option}`}
             listings={ageProducts[option] || []}
-            isLoading={isLoading}
+            isLoading={loadingByAgeGroup[option]}
           />
         ))}
       </div>
@@ -400,7 +404,11 @@ export const AgeNavigation = ({ config }) => {
 const makeCategoryCarousels = (categories) => {
   const CategoryCarousels = ({ config }) => {
     const [categoryProducts, setCategoryProducts] = useState({});
-    const [isLoading, setIsLoading] = useState(true);
+    // Loading tracked per category so a slow category never delays a faster
+    // sibling's carousel from rendering (ProductCarousel takes isLoading per instance).
+    const [loadingByCategory, setLoadingByCategory] = useState(() =>
+      categories.reduce((acc, { id }) => ({ ...acc, [id]: true }), {})
+    );
 
     const DISPLAY_COUNT = 8;
 
@@ -408,51 +416,35 @@ const makeCategoryCarousels = (categories) => {
       const listingFields = config?.listing?.listingFields;
       const sanitizeConfig = { listingFields };
 
-      const fetchProducts = async () => {
-        try {
-          const results = await Promise.all(
-            categories.map(async ({ id }) => {
-              try {
-                const { pool, allIncluded } = await fetchBestsellerCarousel(
-                  sdk,
-                  {
-                    pub_categoryLevel1: id,
-                    include: ['images', 'currentStock'],
-                  },
-                  DISPLAY_COUNT
-                );
+      // Fire each category's fetch independently and update only its own slice
+      // of state on completion — see the matching pattern/rationale in OccasionStrip.
+      categories.forEach(({ id }) => {
+        (async () => {
+          try {
+            const { pool, allIncluded } = await fetchListingsAcrossBrands(
+              sdk,
+              DISCOVERY_BRAND_IDS,
+              {
+                pub_categoryLevel1: id,
+                include: ['author', 'images', 'currentStock'],
+              },
+              PER_BRAND_COUNT
+            );
 
-                // Pick diverse brands from the pool
-                const listingIds = pickBrandDiverse(pool, DISPLAY_COUNT);
-                return { id, listingIds, responseData: { data: pool, included: allIncluded } };
-              } catch {
-                return { id, listingIds: [], responseData: null };
-              }
-            })
-          );
-
-          let allEntities = {};
-          results.forEach(r => {
-            if (r.responseData) {
-              allEntities = updatedEntities(allEntities, r.responseData, sanitizeConfig);
-            }
-          });
-
-          const productsMap = results.reduce((acc, { id, listingIds }) => {
+            // Pick diverse brands from the pool
+            const listingIds = pickBrandDiverse(pool, DISPLAY_COUNT);
+            const entities = updatedEntities({}, { data: pool, included: allIncluded }, sanitizeConfig);
             const refs = listingIds.map(lid => ({ id: lid, type: 'listing' }));
-            acc[id] = denormalisedEntities(allEntities, refs, false);
-            return acc;
-          }, {});
+            const listings = denormalisedEntities(entities, refs, false);
 
-          setCategoryProducts(productsMap);
-        } catch {
-          // leave empty
-        } finally {
-          setIsLoading(false);
-        }
-      };
-
-      fetchProducts();
+            setCategoryProducts(prev => ({ ...prev, [id]: listings }));
+          } catch {
+            setCategoryProducts(prev => ({ ...prev, [id]: [] }));
+          } finally {
+            setLoadingByCategory(prev => ({ ...prev, [id]: false }));
+          }
+        })();
+      });
     }, []); // eslint-disable-line
 
     return (
@@ -464,7 +456,7 @@ const makeCategoryCarousels = (categories) => {
             viewAllLinkName="SearchPage"
             viewAllLinkSearch={viewAllSearch}
             listings={categoryProducts[id] || []}
-            isLoading={isLoading}
+            isLoading={loadingByCategory[id]}
           />
         ))}
       </div>

--- a/src/containers/MelaHomePage/sections/CategoryShowcase/CategoryShowcase.test.js
+++ b/src/containers/MelaHomePage/sections/CategoryShowcase/CategoryShowcase.test.js
@@ -5,7 +5,7 @@ import { IntlProvider } from 'react-intl';
 import '@testing-library/jest-dom';
 
 import { ConfigurationProvider } from '../../../../context/configurationContext';
-import CategoryShowcase, { OccasionStrip, AgeNavigation } from './CategoryShowcase';
+import CategoryShowcase, { OccasionStrip, AgeNavigation, EXCLUDED_DISCOVERY_BRAND_SLUGS } from './CategoryShowcase';
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
 
@@ -71,6 +71,17 @@ jest.mock('../../../../config/settings', () => ({
 
 jest.mock('../../../../util/api', () => ({ typeHandlers: [] }));
 
+// Fixed, small brand list so per-brand query-count assertions below are simple
+// and don't depend on configBrands.js's env-specific (and possibly empty, in
+// the test env's 'production' branch) allBrandIds. None map to an excluded
+// slug, so CategoryShowcase.js's discovery-carousel exclusion filter is a
+// no-op here — none of these 3 test IDs get filtered out.
+const TEST_BRAND_IDS = ['brand-1', 'brand-2', 'brand-3'];
+jest.mock('../../../../config/configBrands', () => ({
+  allBrandIds: ['brand-1', 'brand-2', 'brand-3'],
+  getBrandSlugById: id => ({ 'brand-1': 'slug-1', 'brand-2': 'slug-2', 'brand-3': 'slug-3' }[id]),
+}));
+
 // ── References to the mocked functions ───────────────────────────────────────
 
 // createInstance() is called at CategoryShowcase.js module-load time (during the
@@ -116,6 +127,33 @@ const renderInContext = (ui, config = {}) =>
       </IntlProvider>
     </MemoryRouter>
   );
+
+// ── EXCLUDED_DISCOVERY_BRAND_SLUGS ─────────────────────────────────────────────
+// Guards against a typo in the exclusion list silently no-opping it: each slug
+// must resolve to a real, currently-configured brand UUID via the *real*
+// configBrands.js (bypassing the file-level jest.mock above via requireActual),
+// not the fixed 3-brand test mock used everywhere else in this file.
+
+describe('EXCLUDED_DISCOVERY_BRAND_SLUGS', () => {
+  it('every excluded slug resolves to a real brand UUID in configBrands.js', () => {
+    // configBrands.js resolves brandConfigurations off REACT_APP_ENV at require
+    // time; the test runner's .env sets REACT_APP_ENV=production, whose brand
+    // bucket is intentionally empty (live brand data lives under .development —
+    // see configBrands.js's brandConfigurationsByEnv). Force 'development' via
+    // isolateModules so this checks against the actual populated brand list.
+    const originalEnv = process.env.REACT_APP_ENV;
+    process.env.REACT_APP_ENV = 'development';
+    let getBrandIdBySlug;
+    jest.isolateModules(() => {
+      ({ getBrandIdBySlug } = jest.requireActual('../../../../config/configBrands'));
+    });
+    process.env.REACT_APP_ENV = originalEnv;
+
+    EXCLUDED_DISCOVERY_BRAND_SLUGS.forEach(slug => {
+      expect(getBrandIdBySlug(slug)).toEqual(expect.any(String));
+    });
+  });
+});
 
 // ── CategoryShowcase (default export) ─────────────────────────────────────────
 
@@ -173,12 +211,10 @@ const renderAndWaitForLoad = async (ui, config = {}) => {
 // P1.3: only 2 surviving top-level categories (Fashion, Baby & Kids) fetched by a
 // single carousel component using ALL_CATEGORIES (down from 6 — Home & Kitchen,
 // Jewelry & Accessories, Beauty & Wellness, and Art & Craft are cut from the
-// homepage, still reachable via /categories). Each category goes through
-// fetchBestsellerCarousel's two-step fetch (bestseller-first, then a fallback query
-// padding out the pool) — see util/bestsellerCarousel.js. With the mocked empty
-// response below, the fallback always triggers, so every category yields 2 queries:
-// perPage 20 (Math.max(DISPLAY_COUNT(8) * 2, 20)) for the bestseller step, then
-// perPage 50 for the fallback.
+// homepage, still reachable via /categories). Each category is fetched via
+// fetchListingsAcrossBrands — one small query per configured brand (author_id +
+// perPage: PER_BRAND_COUNT), merged client-side — see util/bestsellerCarousel.js.
+// TEST_BRAND_IDS has 3 brands, so every category yields 3 queries.
 
 describe('AllCategoryCarousels', () => {
   beforeEach(() => {
@@ -187,12 +223,13 @@ describe('AllCategoryCarousels', () => {
     denormalisedEntities.mockReturnValue([]);
   });
 
-  it('queries both surviving categories using the bestseller-first pagination strategy', async () => {
+  it('queries every configured brand for both surviving categories', async () => {
     const calls = await renderAndWaitForLoad(<CategoryShowcase />);
     const catCalls = calls.filter(([p]) => p.pub_categoryLevel1);
-    expect(catCalls).toHaveLength(4); // 2 categories × 2 queries each
+    expect(catCalls).toHaveLength(TEST_BRAND_IDS.length * 2); // 3 brands × 2 categories
     catCalls.forEach(([params]) => {
-      expect([20, 50]).toContain(params.perPage);
+      expect(TEST_BRAND_IDS).toContain(params.author_id);
+      expect(params.perPage).toBe(2);
     });
   });
 
@@ -236,12 +273,15 @@ describe('AgeNavigation', () => {
     denormalisedEntities.mockReturnValue([]);
   });
 
-  it('queries each age group using the bestseller-first pagination strategy', async () => {
+  it('queries every configured brand for each age group', async () => {
     renderInContext(<AgeNavigation config={{}} />);
     await screen.findAllByTestId('product-carousel');
     const ageCalls = mockQuery.mock.calls.filter(([p]) => p.pub_age_group);
-    expect(ageCalls).toHaveLength(6); // 3 age groups × 2 queries each (see AllCategoryCarousels note above)
-    ageCalls.forEach(([params]) => expect([20, 50]).toContain(params.perPage));
+    expect(ageCalls).toHaveLength(TEST_BRAND_IDS.length * 3); // 3 brands × 3 age groups
+    ageCalls.forEach(([params]) => {
+      expect(TEST_BRAND_IDS).toContain(params.author_id);
+      expect(params.perPage).toBe(2);
+    });
   });
 
   it('queries newborn, 0_6_months, 6_12_months', async () => {
@@ -272,17 +312,15 @@ describe('OccasionStrip', () => {
     denormalisedEntities.mockReturnValue([]);
   });
 
-  it('queries each occasion using the bestseller-first pagination strategy', async () => {
+  it('queries every configured brand for each occasion', async () => {
     renderInContext(<OccasionStrip />);
 
     await waitFor(() => {
       const calls = mockQuery.mock.calls.filter(([p]) => p.pub_occasion);
-      // 2 occasions × 2 queries each (see AllCategoryCarousels note above); occasion's
-      // DISPLAY_COUNT is 6, so the bestseller step here also lands on perPage 20
-      // (Math.max(6 * 2, 20)).
-      expect(calls).toHaveLength(4);
+      expect(calls).toHaveLength(TEST_BRAND_IDS.length * 2); // 3 brands × 2 occasions
       calls.forEach(([params]) => {
-        expect([20, 50]).toContain(params.perPage);
+        expect(TEST_BRAND_IDS).toContain(params.author_id);
+        expect(params.perPage).toBe(2);
       });
     });
   });

--- a/src/util/bestsellerCarousel.js
+++ b/src/util/bestsellerCarousel.js
@@ -56,3 +56,78 @@ export const fetchBestsellerCarousel = async (sdk, queryParams, displayCount) =>
     return { pool: [], allIncluded: [] };
   }
 };
+
+// SLA ceiling for a single brand's query within fetchListingsAcrossBrands. A
+// brand that hasn't responded within this window contributes nothing rather
+// than holding up every other (already-responded) brand — "some data beats
+// no data" for a homepage module. Bounds the whole batch to ~this long
+// regardless of brand count, since Promise.all only waits for the slowest of
+// N promises that are each individually capped at PER_BRAND_TIMEOUT_MS.
+export const PER_BRAND_TIMEOUT_MS = 1200;
+
+const EMPTY_BRAND_RESULT = { data: [], included: [] };
+
+// Clears the timeout once the race settles either way — otherwise a fast-
+// resolving query still leaves its timer scheduled for the full `ms`, which
+// leaks pending timers (harmless individually, but they pile up across many
+// per-brand queries and can bleed into unrelated code/tests still running
+// when they eventually fire).
+const withTimeout = (promise, ms) => {
+  let timeoutId;
+  const timeout = new Promise(resolve => {
+    timeoutId = setTimeout(() => resolve(EMPTY_BRAND_RESULT), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timeoutId));
+};
+
+/**
+ * Fetch a few listings from each given brand and merge into one pool.
+ *
+ * Query-time diversity: guarantees every listed brand gets a fair shot at
+ * appearing, instead of relying on marketplace-wide sort order (which can be
+ * dominated by whichever single brand has the most matching/most-recent
+ * listings — see fetchBestsellerCarousel above). Sharetribe's `authorId`
+ * query param only accepts a single UUID (no OR/comma-list support, unlike
+ * `ids`), so this is N parallel single-author queries — the same pattern
+ * BrandsPage.duck.js already uses (fetchBestsellerListingsForBrand) for
+ * per-brand bestseller listings.
+ *
+ * Each per-brand query is capped at `timeoutMs`: a slow or hanging brand
+ * degrades to "no listings from this brand" instead of blocking the whole
+ * pool. This bounds the carousel's total fetch time to ~timeoutMs no matter
+ * how many brands are configured.
+ *
+ * @param {Object} sdk - Sharetribe SDK instance
+ * @param {Array<string>} brandIds - Brand user UUIDs, e.g. from config/configBrands.js
+ * @param {Object} queryParams - Shared query params (filters, include, fields) applied per brand
+ * @param {number} perBrandCount - Max listings to fetch per brand
+ * @param {number} timeoutMs - Per-brand SLA ceiling in ms
+ * @returns {Promise<{pool: Array, allIncluded: Array}>} Combined pool and all included entities
+ */
+export const fetchListingsAcrossBrands = async (
+  sdk,
+  brandIds,
+  queryParams,
+  perBrandCount = 2,
+  timeoutMs = PER_BRAND_TIMEOUT_MS
+) => {
+  const results = await Promise.all(
+    brandIds.map(brandId =>
+      withTimeout(
+        sdk.listings
+          .query({ ...queryParams, author_id: brandId, perPage: perBrandCount })
+          .then(response => ({
+            data: response.data.data || [],
+            included: response.data.included || [],
+          }))
+          .catch(() => EMPTY_BRAND_RESULT),
+        timeoutMs
+      )
+    )
+  );
+
+  return {
+    pool: results.flatMap(r => r.data),
+    allIncluded: results.flatMap(r => r.included),
+  };
+};

--- a/src/util/bestsellerCarousel.test.js
+++ b/src/util/bestsellerCarousel.test.js
@@ -1,0 +1,85 @@
+import { fetchListingsAcrossBrands, PER_BRAND_TIMEOUT_MS } from './bestsellerCarousel';
+
+const makeListing = uuid => ({ id: { uuid }, type: 'listing' });
+
+const respondWith = (data, included = []) =>
+  Promise.resolve({ data: { data, included } });
+
+describe('fetchListingsAcrossBrands', () => {
+  it('merges pool and included entities across all brands', async () => {
+    const sdk = {
+      listings: {
+        query: jest.fn(params => {
+          if (params.author_id === 'brand-a') {
+            return respondWith([makeListing('a1')], [{ id: { uuid: 'img-a1' }, type: 'image' }]);
+          }
+          return respondWith([makeListing('b1')], [{ id: { uuid: 'img-b1' }, type: 'image' }]);
+        }),
+      },
+    };
+
+    const { pool, allIncluded } = await fetchListingsAcrossBrands(
+      sdk,
+      ['brand-a', 'brand-b'],
+      { pub_occasion: 'gifting' },
+      2
+    );
+
+    expect(pool.map(l => l.id.uuid).sort()).toEqual(['a1', 'b1']);
+    expect(allIncluded.map(i => i.id.uuid).sort()).toEqual(['img-a1', 'img-b1']);
+  });
+
+  it('queries each brand with author_id and the shared perBrandCount as perPage', async () => {
+    const sdk = { listings: { query: jest.fn(() => respondWith([])) } };
+
+    await fetchListingsAcrossBrands(sdk, ['brand-a', 'brand-b'], { pub_occasion: 'gifting' }, 3);
+
+    expect(sdk.listings.query).toHaveBeenCalledWith(
+      expect.objectContaining({ author_id: 'brand-a', perPage: 3, pub_occasion: 'gifting' })
+    );
+    expect(sdk.listings.query).toHaveBeenCalledWith(
+      expect.objectContaining({ author_id: 'brand-b', perPage: 3, pub_occasion: 'gifting' })
+    );
+  });
+
+  it('contributes an empty result for a brand whose query rejects, without failing the batch', async () => {
+    const sdk = {
+      listings: {
+        query: jest.fn(params =>
+          params.author_id === 'brand-bad'
+            ? Promise.reject(new Error('network error'))
+            : respondWith([makeListing('ok1')])
+        ),
+      },
+    };
+
+    const { pool } = await fetchListingsAcrossBrands(sdk, ['brand-bad', 'brand-ok'], {}, 2);
+
+    expect(pool.map(l => l.id.uuid)).toEqual(['ok1']);
+  });
+
+  it('does not let a hanging brand query block the batch past the SLA timeout', async () => {
+    jest.useFakeTimers();
+
+    const sdk = {
+      listings: {
+        query: jest.fn(params =>
+          params.author_id === 'brand-slow'
+            ? new Promise(() => {}) // never resolves
+            : respondWith([makeListing('fast1')])
+        ),
+      },
+    };
+
+    const resultPromise = fetchListingsAcrossBrands(sdk, ['brand-slow', 'brand-fast'], {}, 2);
+
+    // Advance past the SLA ceiling; the hanging brand's timeout should fire.
+    await jest.advanceTimersByTimeAsync(PER_BRAND_TIMEOUT_MS);
+
+    const { pool } = await resultPromise;
+
+    expect(pool.map(l => l.id.uuid)).toEqual(['fast1']);
+
+    jest.useRealTimers();
+  });
+});


### PR DESCRIPTION
…scovery carousels

Replace marketplace-wide pooled queries with per-brand queries (fetchListingsAcrossBrands) across OccasionStrip, AgeNavigation, and AllCategoryCarousels so no single brand's inventory can dominate the pool before diversification runs.

- Bound each per-brand query to PER_BRAND_TIMEOUT_MS (1200ms) so one slow/hanging brand can't stall the whole carousel; timers are cleared on settle to avoid leaking pending timers.
- Track loading state per occasion/age-group/category instead of one shared flag, so each panel renders as soon as its own data is back instead of waiting on the slowest sibling.
- Add EXCLUDED_DISCOVERY_BRAND_SLUGS to opt specific brands (superbottoms, isharya) out of these homepage carousels while keeping them everywhere else (search, category pages, their own storefronts).